### PR TITLE
feat: add baby menu screen and unify app bar theming

### DIFF
--- a/baby_track_app/lib/features/baby/presentation/pages/baby_list_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_list_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:baby_track_app/features/baby/domain/models/baby.dart';
 import 'package:baby_track_app/features/baby/infrastructure/baby_repository_impl.dart';
+import 'package:baby_track_app/features/baby/presentation/pages/baby_menu_page.dart';
 import 'package:baby_track_app/features/baby/presentation/pages/baby_registration_page.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -99,6 +100,25 @@ class _BabyListPageState extends State<BabyListPage> {
     }
   }
 
+  LinearGradient _buildAppBarGradient(ColorScheme colorScheme) {
+    final blendedColor =
+        Color.lerp(colorScheme.primary, colorScheme.secondary, 0.5) ??
+            colorScheme.primary;
+
+    return LinearGradient(
+      colors: [colorScheme.primary, blendedColor, colorScheme.secondary],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    );
+  }
+
+  Future<void> _openBabyMenu(Baby baby) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => BabyMenuPage(baby: baby)),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -138,6 +158,7 @@ class _BabyListPageState extends State<BabyListPage> {
                       colorScheme: colorScheme,
                       onEdit: _editBaby,
                       onDelete: _deleteBaby,
+                      onOpen: _openBabyMenu,
                     ),
             ],
           ),
@@ -178,15 +199,7 @@ class _BabyListPageState extends State<BabyListPage> {
       ),
       flexibleSpace: Container(
         decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              colorScheme.primary,
-              colorScheme.primary.withOpacity(0.85),
-              const Color(0xFFFF8A65),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
+          gradient: _buildAppBarGradient(colorScheme),
         ),
       ),
       title: Row(
@@ -238,12 +251,14 @@ class _BabyGrid extends StatelessWidget {
     required this.colorScheme,
     required this.onEdit,
     required this.onDelete,
+    required this.onOpen,
   });
 
   final List<Baby> babies;
   final ColorScheme colorScheme;
   final Function(Baby) onEdit;
   final Function(Baby) onDelete;
+  final Function(Baby) onOpen;
 
   @override
   Widget build(BuildContext context) {
@@ -268,6 +283,7 @@ class _BabyGrid extends StatelessWidget {
             colorScheme: colorScheme,
             onEdit: () => onEdit(babies[index]),
             onDelete: () => onDelete(babies[index]),
+            onOpen: () => onOpen(babies[index]),
           );
         },
       ),
@@ -281,12 +297,14 @@ class _BabyCard extends StatelessWidget {
     required this.colorScheme,
     required this.onEdit,
     required this.onDelete,
+    required this.onOpen,
   });
 
   final Baby baby;
   final ColorScheme colorScheme;
   final VoidCallback onEdit;
   final VoidCallback onDelete;
+  final VoidCallback onOpen;
 
   String _getAge() {
     final now = DateTime.now();
@@ -311,134 +329,153 @@ class _BabyCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
 
-    return Container(
-      decoration: BoxDecoration(
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onOpen,
         borderRadius: BorderRadius.circular(24),
-        gradient: LinearGradient(
-          colors: [colorScheme.primary.withOpacity(0.12), Colors.white],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.08),
-            blurRadius: 20,
-            offset: const Offset(0, 10),
-          ),
-        ],
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(14), // Reducido padding
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min, // Importante para evitar overflow
-          children: [
-            // Photo
-            Container(
-              width: 60, // Reducido tamaño
-              height: 60,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: baby.gender == 'M'
-                    ? Colors.blue.withOpacity(0.2)
-                    : Colors.pink.withOpacity(0.2),
-                border: Border.all(
-                  color: baby.gender == 'M'
-                      ? Colors.blue.withOpacity(0.3)
-                      : Colors.pink.withOpacity(0.3),
-                  width: 2,
-                ),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(24),
+            gradient: LinearGradient(
+              colors: [colorScheme.primary.withOpacity(0.12), Colors.white],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.08),
+                blurRadius: 20,
+                offset: const Offset(0, 10),
               ),
-              child: baby.photoPath != null && baby.photoPath!.isNotEmpty
-                  ? ClipOval(
-                      child: Image.file(
-                        File(baby.photoPath!),
-                        fit: BoxFit.cover,
-                        errorBuilder: (context, error, stackTrace) => Icon(
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(14), // Reducido padding
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min, // Importante para evitar overflow
+              children: [
+                // Photo
+                Container(
+                  width: 60, // Reducido tamaño
+                  height: 60,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: baby.gender == 'M'
+                        ? Colors.blue.withOpacity(0.2)
+                        : Colors.pink.withOpacity(0.2),
+                    border: Border.all(
+                      color: baby.gender == 'M'
+                          ? Colors.blue.withOpacity(0.3)
+                          : Colors.pink.withOpacity(0.3),
+                      width: 2,
+                    ),
+                  ),
+                  child: baby.photoPath != null && baby.photoPath!.isNotEmpty
+                      ? ClipOval(
+                          child: Image.file(
+                            File(baby.photoPath!),
+                            fit: BoxFit.cover,
+                            errorBuilder: (context, error, stackTrace) => Icon(
+                              baby.gender == 'M' ? Icons.boy : Icons.girl,
+                              size: 28, // Reducido tamaño
+                              color: baby.gender == 'M' ? Colors.blue : Colors.pink,
+                            ),
+                          ),
+                        )
+                      : Icon(
                           baby.gender == 'M' ? Icons.boy : Icons.girl,
                           size: 28, // Reducido tamaño
                           color: baby.gender == 'M' ? Colors.blue : Colors.pink,
                         ),
-                      ),
-                    )
-                  : Icon(
-                      baby.gender == 'M' ? Icons.boy : Icons.girl,
-                      size: 28, // Reducido tamaño
-                      color: baby.gender == 'M' ? Colors.blue : Colors.pink,
-                    ),
-            ),
-            const SizedBox(height: 8), // Reducido espaciado
-            // Name
-            Text(
-              baby.name,
-              style: textTheme.titleSmall?.copyWith(
-                // Cambiado a titleSmall
-                fontWeight: FontWeight.w700,
-                color: colorScheme.primary,
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-            const SizedBox(height: 2), // Reducido espaciado
-            // Age
-            Text(
-              _getAge(),
-              style: textTheme.bodySmall?.copyWith(
-                color: Colors.grey[600],
-                fontWeight: FontWeight.w500,
-                fontSize: 11, // Tamaño específico más pequeño
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 2, // Permitir 2 líneas para edad
-              overflow: TextOverflow.ellipsis,
-            ),
-            const SizedBox(height: 4), // Reducido espaciado
-            // Birth date
-            Text(
-              DateFormat('dd/MM/yyyy').format(baby.birthDate),
-              style: textTheme.bodySmall?.copyWith(
-                color: Colors.grey[500],
-                fontSize: 10, // Tamaño más pequeño
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8), // Espacio fijo en lugar de Spacer
-            // Action buttons - Compactos
-            Row(
-              children: [
-                Expanded(
-                  child: SizedBox(
-                    height: 32, // Altura fija más pequeña
-                    child: IconButton(
-                      onPressed: onEdit,
-                      icon: Icon(Icons.edit_rounded, color: colorScheme.primary, size: 16),
-                      style: IconButton.styleFrom(
-                        backgroundColor: colorScheme.primary.withOpacity(0.1),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
-                        padding: EdgeInsets.zero, // Sin padding extra
-                      ),
-                    ),
-                  ),
                 ),
-                const SizedBox(width: 6), // Reducido espaciado
-                Expanded(
-                  child: SizedBox(
-                    height: 32, // Altura fija más pequeña
-                    child: IconButton(
-                      onPressed: onDelete,
-                      icon: const Icon(Icons.delete_rounded, color: Colors.red, size: 16),
-                      style: IconButton.styleFrom(
-                        backgroundColor: Colors.red.withOpacity(0.1),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
-                        padding: EdgeInsets.zero, // Sin padding extra
+                const SizedBox(height: 8), // Reducido espaciado
+                // Name
+                Text(
+                  baby.name,
+                  style: textTheme.titleSmall?.copyWith(
+                    // Cambiado a titleSmall
+                    fontWeight: FontWeight.w700,
+                    color: colorScheme.primary,
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2), // Reducido espaciado
+                // Age
+                Text(
+                  _getAge(),
+                  style: textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[600],
+                    fontWeight: FontWeight.w500,
+                    fontSize: 11, // Tamaño específico más pequeño
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 2, // Permitir 2 líneas para edad
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4), // Reducido espaciado
+                // Birth date
+                Text(
+                  DateFormat('dd/MM/yyyy').format(baby.birthDate),
+                  style: textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[500],
+                    fontSize: 10, // Tamaño más pequeño
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8), // Espacio fijo en lugar de Spacer
+                // Action buttons - Compactos
+                Row(
+                  children: [
+                    Expanded(
+                      child: SizedBox(
+                        height: 32, // Altura fija más pequeña
+                        child: IconButton(
+                          onPressed: onEdit,
+                          icon: Icon(
+                            Icons.edit_rounded,
+                            color: colorScheme.primary,
+                            size: 16,
+                          ),
+                          style: IconButton.styleFrom(
+                            backgroundColor: colorScheme.primary.withOpacity(0.1),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            padding: EdgeInsets.zero, // Sin padding extra
+                          ),
+                        ),
                       ),
                     ),
-                  ),
+                    const SizedBox(width: 6), // Reducido espaciado
+                    Expanded(
+                      child: SizedBox(
+                        height: 32, // Altura fija más pequeña
+                        child: IconButton(
+                          onPressed: onDelete,
+                          icon: const Icon(
+                            Icons.delete_rounded,
+                            color: Colors.red,
+                            size: 16,
+                          ),
+                          style: IconButton.styleFrom(
+                            backgroundColor: Colors.red.withOpacity(0.1),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            padding: EdgeInsets.zero, // Sin padding extra
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
@@ -1,0 +1,560 @@
+import 'dart:io';
+
+import 'package:baby_track_app/features/baby/domain/models/baby.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class BabyMenuPage extends StatelessWidget {
+  const BabyMenuPage({super.key, required this.baby});
+
+  final Baby baby;
+
+  LinearGradient _buildAppBarGradient(ColorScheme colorScheme) {
+    final blendedColor =
+        Color.lerp(colorScheme.primary, colorScheme.secondary, 0.5) ??
+            colorScheme.primary;
+
+    return LinearGradient(
+      colors: [colorScheme.primary, blendedColor, colorScheme.secondary],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    );
+  }
+
+  String _formatAge() {
+    final now = DateTime.now();
+    final difference = now.difference(baby.birthDate);
+
+    if (difference.inDays < 30) {
+      return '${difference.inDays} ${difference.inDays == 1 ? 'día' : 'días'}';
+    }
+
+    if (difference.inDays < 365) {
+      final months = (difference.inDays / 30).floor();
+      return '$months ${months == 1 ? 'mes' : 'meses'}';
+    }
+
+    final years = (difference.inDays / 365).floor();
+    final remainingMonths = ((difference.inDays % 365) / 30).floor();
+    if (remainingMonths == 0) {
+      return '$years ${years == 1 ? 'año' : 'años'}';
+    }
+    return '$years ${years == 1 ? 'año' : 'años'} y $remainingMonths ${remainingMonths == 1 ? 'mes' : 'meses'}';
+  }
+
+  String _genderLabel() {
+    switch (baby.gender) {
+      case 'M':
+        return 'Niño';
+      case 'F':
+        return 'Niña';
+      default:
+        return 'Sin especificar';
+    }
+  }
+
+  Color _genderColor(ColorScheme colorScheme) {
+    switch (baby.gender) {
+      case 'M':
+        return colorScheme.primary;
+      case 'F':
+        return colorScheme.secondary;
+      default:
+        return colorScheme.tertiary;
+    }
+  }
+
+  void _showComingSoon(BuildContext context, String featureName) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text('$featureName estará disponible muy pronto.'),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    final actions = [
+      _BabyActionCardData(
+        title: 'REGISTRO',
+        description:
+            'Anota tomas, pañales, siestas y observaciones importantes del día a día.',
+        icon: Icons.edit_note_rounded,
+        accentColor: colorScheme.primary,
+        backgroundColors: [
+          colorScheme.primary.withOpacity(0.18),
+          colorScheme.primary.withOpacity(0.08),
+        ],
+      ),
+      _BabyActionCardData(
+        title: 'HISTORIAL',
+        description: 'Revisa los registros anteriores y detecta patrones fácilmente.',
+        icon: Icons.history_rounded,
+        accentColor: colorScheme.secondary,
+        backgroundColors: [
+          colorScheme.secondary.withOpacity(0.18),
+          colorScheme.secondary.withOpacity(0.08),
+        ],
+      ),
+    ];
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        centerTitle: false,
+        leading: Container(
+          margin: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.15),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: Colors.white.withOpacity(0.2)),
+          ),
+          child: IconButton(
+            onPressed: () => Navigator.pop(context),
+            icon: const Icon(Icons.arrow_back_ios_new, color: Colors.white, size: 20),
+            tooltip: 'Volver',
+          ),
+        ),
+        flexibleSpace: Container(
+          decoration: BoxDecoration(
+            gradient: _buildAppBarGradient(colorScheme),
+          ),
+        ),
+        title: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.2),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.white.withOpacity(0.3)),
+              ),
+              child: const Icon(Icons.child_friendly_rounded, color: Colors.white, size: 24),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    baby.name,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                      fontSize: 18,
+                      letterSpacing: 0.5,
+                    ),
+                  ),
+                  Text(
+                    'Edad: ${_formatAge()}',
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.85),
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [colorScheme.surface, colorScheme.surface.withOpacity(0.85)],
+          ),
+        ),
+        child: SafeArea(
+          child: Stack(
+            children: [
+              Positioned(
+                top: -60,
+                right: -20,
+                child: _DecorativeBubble(
+                  size: 180,
+                  color: colorScheme.secondary.withOpacity(0.25),
+                ),
+              ),
+              Positioned(
+                bottom: -40,
+                left: -30,
+                child: _DecorativeBubble(
+                  size: 140,
+                  color: colorScheme.primary.withOpacity(0.18),
+                ),
+              ),
+              SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _BabySummaryCard(
+                      baby: baby,
+                      colorScheme: colorScheme,
+                      textTheme: textTheme,
+                      genderLabel: _genderLabel(),
+                      genderColor: _genderColor(colorScheme),
+                      ageLabel: _formatAge(),
+                    ),
+                    const SizedBox(height: 32),
+                    Text(
+                      'Acciones rápidas',
+                      style: textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: colorScheme.primary,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      'Selecciona una opción para gestionar la información de ${baby.name}.',
+                      style: textTheme.bodyMedium?.copyWith(height: 1.5),
+                    ),
+                    const SizedBox(height: 24),
+                    LayoutBuilder(
+                      builder: (context, constraints) {
+                        final isWide = constraints.maxWidth >= 600;
+                        final cardWidth = isWide
+                            ? (constraints.maxWidth - 16) / 2
+                            : constraints.maxWidth;
+                        return Wrap(
+                          spacing: 16,
+                          runSpacing: 16,
+                          children: actions
+                              .map(
+                                (action) => SizedBox(
+                                  width: cardWidth,
+                                  child: _BabyActionCard(
+                                    data: action,
+                                    onTap: () => _showComingSoon(context, action.title),
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BabySummaryCard extends StatelessWidget {
+  const _BabySummaryCard({
+    required this.baby,
+    required this.colorScheme,
+    required this.textTheme,
+    required this.genderLabel,
+    required this.genderColor,
+    required this.ageLabel,
+  });
+
+  final Baby baby;
+  final ColorScheme colorScheme;
+  final TextTheme textTheme;
+  final String genderLabel;
+  final Color genderColor;
+  final String ageLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(28),
+        gradient: LinearGradient(
+          colors: [colorScheme.primary.withOpacity(0.12), Colors.white],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.08),
+            blurRadius: 24,
+            offset: const Offset(0, 16),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _BabyAvatar(
+                  baby: baby,
+                  colorScheme: colorScheme,
+                  genderColor: genderColor,
+                ),
+                const SizedBox(width: 20),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        baby.name,
+                        style: textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: colorScheme.primary,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          _InfoPill(
+                            icon: Icons.cake_outlined,
+                            label: DateFormat('dd/MM/yyyy').format(baby.birthDate),
+                          ),
+                          _InfoPill(
+                            icon: Icons.calendar_month_rounded,
+                            label: ageLabel,
+                          ),
+                          _InfoPill(
+                            icon: Icons.waving_hand_rounded,
+                            label: genderLabel,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            Divider(color: colorScheme.primary.withOpacity(0.2)),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Icon(Icons.info_outline_rounded, color: colorScheme.primary, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Perfil creado el ${DateFormat('dd/MM/yyyy').format(baby.createdAt)}',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: Colors.grey[700],
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BabyAvatar extends StatelessWidget {
+  const _BabyAvatar({
+    required this.baby,
+    required this.colorScheme,
+    required this.genderColor,
+  });
+
+  final Baby baby;
+  final ColorScheme colorScheme;
+  final Color genderColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 80,
+      height: 80,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: genderColor.withOpacity(0.15),
+        border: Border.all(color: genderColor.withOpacity(0.25), width: 2),
+      ),
+      child: ClipOval(
+        child: baby.photoPath != null && baby.photoPath!.isNotEmpty
+            ? Image.file(
+                File(baby.photoPath!),
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) => Icon(
+                  baby.gender == 'M'
+                      ? Icons.boy_rounded
+                      : baby.gender == 'F'
+                          ? Icons.girl_rounded
+                          : Icons.child_care,
+                  color: genderColor,
+                  size: 40,
+                ),
+              )
+            : Icon(
+                baby.gender == 'M'
+                    ? Icons.boy_rounded
+                    : baby.gender == 'F'
+                        ? Icons.girl_rounded
+                        : Icons.child_care,
+                color: genderColor,
+                size: 40,
+              ),
+      ),
+    );
+  }
+}
+
+class _InfoPill extends StatelessWidget {
+  const _InfoPill({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Colors.grey.withOpacity(0.2)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: Colors.grey[700]),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: Colors.grey[700],
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BabyActionCard extends StatelessWidget {
+  const _BabyActionCard({required this.data, required this.onTap});
+
+  final _BabyActionCardData data;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(24),
+        child: Container(
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(24),
+            gradient: LinearGradient(
+              colors: [
+                data.backgroundColors.first,
+                data.backgroundColors.last,
+                Colors.white,
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.06),
+                blurRadius: 20,
+                offset: const Offset(0, 12),
+              ),
+            ],
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(14),
+                decoration: BoxDecoration(
+                  color: data.accentColor.withOpacity(0.18),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(data.icon, color: data.accentColor, size: 28),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                data.title,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+              ),
+              const SizedBox(height: 10),
+              Text(
+                data.description,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(height: 1.5),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                children: [
+                  Text(
+                    'Abrir',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: data.accentColor,
+                          fontWeight: FontWeight.w600,
+                        ),
+                  ),
+                  const SizedBox(width: 8),
+                  Icon(Icons.arrow_forward_rounded, color: data.accentColor, size: 18),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BabyActionCardData {
+  const _BabyActionCardData({
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.accentColor,
+    required this.backgroundColors,
+  });
+
+  final String title;
+  final String description;
+  final IconData icon;
+  final Color accentColor;
+  final List<Color> backgroundColors;
+}
+
+class _DecorativeBubble extends StatelessWidget {
+  const _DecorativeBubble({required this.size, required this.color});
+
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+  }
+}

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_selection_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_selection_page.dart
@@ -37,6 +37,18 @@ class _BabySelectionPageState extends State<BabySelectionPage> {
     }
   }
 
+  LinearGradient _buildAppBarGradient(ColorScheme colorScheme) {
+    final blendedColor =
+        Color.lerp(colorScheme.primary, colorScheme.secondary, 0.5) ??
+            colorScheme.primary;
+
+    return LinearGradient(
+      colors: [colorScheme.primary, blendedColor, colorScheme.secondary],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -114,15 +126,7 @@ class _BabySelectionPageState extends State<BabySelectionPage> {
       automaticallyImplyLeading: false,
       flexibleSpace: Container(
         decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              colorScheme.primary,
-              colorScheme.primary.withOpacity(0.85),
-              const Color(0xFFFF8A65),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
+          gradient: _buildAppBarGradient(colorScheme),
         ),
       ),
       title: Row(

--- a/baby_track_app/lib/features/settings/presentation/pages/settings_page.dart
+++ b/baby_track_app/lib/features/settings/presentation/pages/settings_page.dart
@@ -66,28 +66,30 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 
+  LinearGradient _buildAppBarGradient(ColorScheme colorScheme) {
+    final blendedColor =
+        Color.lerp(colorScheme.primary, colorScheme.secondary, 0.5) ??
+            colorScheme.primary;
+
+    return LinearGradient(
+      colors: [colorScheme.primary, blendedColor, colorScheme.secondary],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    );
+  }
+
   PreferredSizeWidget _buildCustomAppBar(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return PreferredSize(
-      preferredSize: const Size.fromHeight(100),
-      child: AppBar(
-        elevation: 0,
-        backgroundColor: Colors.transparent,
-        flexibleSpace: Container(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                colorScheme.primary,
-                colorScheme.primary.withOpacity(0.85),
-                colorScheme.secondary,
-              ],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-          ),
+    return AppBar(
+      elevation: 0,
+      backgroundColor: Colors.transparent,
+      flexibleSpace: Container(
+        decoration: BoxDecoration(
+          gradient: _buildAppBarGradient(colorScheme),
         ),
-        title: Row(
+      ),
+      title: Row(
           children: [
             Container(
               padding: const EdgeInsets.all(10),
@@ -126,17 +128,17 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
           ],
         ),
-        leading: IconButton(
-          onPressed: () => Navigator.pop(context),
-          icon: Container(
-            padding: const EdgeInsets.all(8),
-            decoration: BoxDecoration(
-              color: Colors.white.withOpacity(0.2),
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: Colors.white.withOpacity(0.3)),
-            ),
-            child: const Icon(Icons.arrow_back_ios, color: Colors.white, size: 16),
+      ),
+      leading: IconButton(
+        onPressed: () => Navigator.pop(context),
+        icon: Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.2),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: Colors.white.withOpacity(0.3)),
           ),
+          child: const Icon(Icons.arrow_back_ios, color: Colors.white, size: 16),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- align the custom AppBar gradients with the active theme and normalize the settings AppBar height
- add the baby menu overview with quick action cards for Registro and Historial
- wire baby cards to open the new menu screen for each profile

## Testing
- not run (flutter tooling is unavailable in the execution environment)

## Agente responsable
- Agente UI/UX

------
https://chatgpt.com/codex/tasks/task_b_68dcf87d7fac8332b3007149e870d842