### PR TITLE
feat: add daily log registration page

### DIFF
--- a/baby_track_app/lib/features/baby/domain/models/baby_daily_log.dart
+++ b/baby_track_app/lib/features/baby/domain/models/baby_daily_log.dart
@@ -1,0 +1,83 @@
+class BabyDailyLog {
+  const BabyDailyLog({
+    this.id,
+    required this.babyId,
+    required this.logDay,
+    required this.loggedAt,
+    this.intakeMl,
+    this.didPoop = false,
+    this.showered = false,
+    this.notes,
+    required this.createdAt,
+    this.updatedAt,
+  });
+
+  final int? id;
+  final int babyId;
+  final DateTime logDay;
+  final DateTime loggedAt;
+  final int? intakeMl;
+  final bool didPoop;
+  final bool showered;
+  final String? notes;
+  final DateTime createdAt;
+  final DateTime? updatedAt;
+
+  BabyDailyLog copyWith({
+    int? id,
+    int? babyId,
+    DateTime? logDay,
+    DateTime? loggedAt,
+    int? intakeMl,
+    bool? didPoop,
+    bool? showered,
+    String? notes,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return BabyDailyLog(
+      id: id ?? this.id,
+      babyId: babyId ?? this.babyId,
+      logDay: logDay ?? this.logDay,
+      loggedAt: loggedAt ?? this.loggedAt,
+      intakeMl: intakeMl ?? this.intakeMl,
+      didPoop: didPoop ?? this.didPoop,
+      showered: showered ?? this.showered,
+      notes: notes ?? this.notes,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'baby_id': babyId,
+      'log_day': DateTime(logDay.year, logDay.month, logDay.day).millisecondsSinceEpoch,
+      'logged_at': loggedAt.millisecondsSinceEpoch,
+      'intake_ml': intakeMl,
+      'did_poop': didPoop ? 1 : 0,
+      'showered': showered ? 1 : 0,
+      'notes': notes,
+      'created_at': createdAt.millisecondsSinceEpoch,
+      'updated_at': updatedAt?.millisecondsSinceEpoch,
+    };
+  }
+
+  factory BabyDailyLog.fromJson(Map<String, dynamic> json) {
+    return BabyDailyLog(
+      id: json['id'] as int?,
+      babyId: json['baby_id'] as int,
+      logDay: DateTime.fromMillisecondsSinceEpoch(json['log_day'] as int),
+      loggedAt: DateTime.fromMillisecondsSinceEpoch(json['logged_at'] as int),
+      intakeMl: json['intake_ml'] as int?,
+      didPoop: (json['did_poop'] as int) == 1,
+      showered: (json['showered'] as int) == 1,
+      notes: json['notes'] as String?,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(json['created_at'] as int),
+      updatedAt: json['updated_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(json['updated_at'] as int)
+          : null,
+    );
+  }
+}

--- a/baby_track_app/lib/features/baby/domain/repositories/baby_daily_log_repository.dart
+++ b/baby_track_app/lib/features/baby/domain/repositories/baby_daily_log_repository.dart
@@ -1,0 +1,6 @@
+import 'package:baby_track_app/features/baby/domain/models/baby_daily_log.dart';
+
+abstract class BabyDailyLogRepository {
+  Future<BabyDailyLog> createLog(BabyDailyLog log);
+  Future<List<BabyDailyLog>> getLogsForBabyOnDate(int babyId, DateTime date);
+}

--- a/baby_track_app/lib/features/baby/infrastructure/baby_daily_log_repository_impl.dart
+++ b/baby_track_app/lib/features/baby/infrastructure/baby_daily_log_repository_impl.dart
@@ -1,0 +1,53 @@
+import 'package:baby_track_app/features/baby/domain/models/baby_daily_log.dart';
+import 'package:baby_track_app/features/baby/domain/repositories/baby_daily_log_repository.dart';
+import 'package:baby_track_app/shared/data/database/database_helper.dart';
+
+class BabyDailyLogRepositoryImpl implements BabyDailyLogRepository {
+  BabyDailyLogRepositoryImpl({DatabaseHelper? databaseHelper})
+    : _databaseHelper = databaseHelper ?? DatabaseHelper();
+
+  final DatabaseHelper _databaseHelper;
+
+  @override
+  Future<BabyDailyLog> createLog(BabyDailyLog log) async {
+    final db = await _databaseHelper.database;
+    final normalizedDay = DateTime(log.logDay.year, log.logDay.month, log.logDay.day);
+    final normalizedDateTime = DateTime(
+      normalizedDay.year,
+      normalizedDay.month,
+      normalizedDay.day,
+      log.loggedAt.hour,
+      log.loggedAt.minute,
+    );
+    final now = DateTime.now();
+
+    final logToInsert = log.copyWith(
+      logDay: normalizedDay,
+      loggedAt: normalizedDateTime,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    final id = await db.insert(
+      'baby_daily_logs',
+      logToInsert.toJson()..remove('id'),
+    );
+
+    return logToInsert.copyWith(id: id);
+  }
+
+  @override
+  Future<List<BabyDailyLog>> getLogsForBabyOnDate(int babyId, DateTime date) async {
+    final db = await _databaseHelper.database;
+    final normalizedDay = DateTime(date.year, date.month, date.day).millisecondsSinceEpoch;
+
+    final result = await db.query(
+      'baby_daily_logs',
+      where: 'baby_id = ? AND log_day = ?',
+      whereArgs: [babyId, normalizedDay],
+      orderBy: 'logged_at ASC',
+    );
+
+    return result.map(BabyDailyLog.fromJson).toList();
+  }
+}

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_daily_log_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_daily_log_page.dart
@@ -1,0 +1,592 @@
+import 'package:baby_track_app/features/baby/domain/models/baby.dart';
+import 'package:baby_track_app/features/baby/domain/models/baby_daily_log.dart';
+import 'package:baby_track_app/features/baby/infrastructure/baby_daily_log_repository_impl.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+
+class BabyDailyLogPage extends StatefulWidget {
+  const BabyDailyLogPage({super.key, required this.baby});
+
+  final Baby baby;
+
+  @override
+  State<BabyDailyLogPage> createState() => _BabyDailyLogPageState();
+}
+
+class _BabyDailyLogPageState extends State<BabyDailyLogPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _mlController = TextEditingController();
+  final _notesController = TextEditingController();
+  final _repository = BabyDailyLogRepositoryImpl();
+
+  late DateTime _selectedDay;
+  TimeOfDay _selectedTime = TimeOfDay.now();
+  bool _didPoop = false;
+  bool _showered = false;
+  bool _isSaving = false;
+  bool _isLoadingLogs = false;
+  List<BabyDailyLog> _logs = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now();
+    _selectedDay = DateTime(now.year, now.month, now.day);
+    if (widget.baby.id != null) {
+      _loadLogs();
+    }
+  }
+
+  @override
+  void dispose() {
+    _mlController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadLogs() async {
+    if (widget.baby.id == null) {
+      return;
+    }
+
+    setState(() {
+      _isLoadingLogs = true;
+    });
+
+    try {
+      final logs = await _repository.getLogsForBabyOnDate(widget.baby.id!, _selectedDay);
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _logs = logs;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingLogs = false;
+        });
+      }
+    }
+  }
+
+  void _changeDay(int offset) {
+    setState(() {
+      _selectedDay = _selectedDay.add(Duration(days: offset));
+    });
+    _loadLogs();
+  }
+
+  Future<void> _pickTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: _selectedTime,
+      builder: (context, child) {
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),
+          child: child!,
+        );
+      },
+    );
+
+    if (picked != null) {
+      setState(() {
+        _selectedTime = picked;
+      });
+    }
+  }
+
+  Future<void> _saveLog() async {
+    if (widget.baby.id == null) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(
+            content: Text('Debes guardar al bebé antes de crear registros diarios.'),
+          ),
+        );
+      return;
+    }
+
+    if (_formKey.currentState?.validate() != true) {
+      return;
+    }
+
+    FocusScope.of(context).unfocus();
+
+    final intakeText = _mlController.text.trim();
+    final notesText = _notesController.text.trim();
+    final normalizedDay = DateTime(_selectedDay.year, _selectedDay.month, _selectedDay.day);
+    final logDateTime = DateTime(
+      normalizedDay.year,
+      normalizedDay.month,
+      normalizedDay.day,
+      _selectedTime.hour,
+      _selectedTime.minute,
+    );
+
+    final log = BabyDailyLog(
+      babyId: widget.baby.id!,
+      logDay: normalizedDay,
+      loggedAt: logDateTime,
+      intakeMl: intakeText.isEmpty ? null : int.parse(intakeText),
+      didPoop: _didPoop,
+      showered: _showered,
+      notes: notesText.isEmpty ? null : notesText,
+      createdAt: DateTime.now(),
+    );
+
+    setState(() {
+      _isSaving = true;
+    });
+
+    try {
+      await _repository.createLog(log);
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text('Registro guardado para ${_formatDayLabel(_selectedDay)}'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+
+      _resetForm();
+      await _loadLogs();
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text('Error al guardar el registro: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
+    }
+  }
+
+  void _resetForm() {
+    setState(() {
+      _mlController.clear();
+      _notesController.clear();
+      _didPoop = false;
+      _showered = false;
+      _selectedTime = TimeOfDay.now();
+    });
+  }
+
+  String _formatDayLabel(DateTime date) {
+    return toBeginningOfSentenceCase(DateFormat("EEEE d 'de' MMMM", 'es').format(date)) ??
+        DateFormat('dd/MM/yyyy').format(date);
+  }
+
+  String _formatTimeLabel(TimeOfDay timeOfDay) {
+    final date = DateTime(0, 1, 1, timeOfDay.hour, timeOfDay.minute);
+    return DateFormat('HH:mm').format(date);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Registro diario de ${widget.baby.name}'),
+      ),
+      body: SafeArea(
+        child: widget.baby.id == null
+            ? Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text(
+                    'Guarda primero la información de ${widget.baby.name} para comenzar a registrar sus actividades diarias.',
+                    textAlign: TextAlign.center,
+                    style: textTheme.bodyLarge,
+                  ),
+                ),
+              )
+            : SingleChildScrollView(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _DayNavigator(
+                      dayLabel: _formatDayLabel(_selectedDay),
+                      onPrevious: () => _changeDay(-1),
+                      onNext: () => _changeDay(1),
+                      colorScheme: colorScheme,
+                    ),
+                    const SizedBox(height: 24),
+                    _buildFormCard(colorScheme, textTheme),
+                    const SizedBox(height: 32),
+                    Text(
+                      'Registros guardados',
+                      style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                    const SizedBox(height: 12),
+                    _buildLogsSection(colorScheme, textTheme),
+                  ],
+                ),
+              ),
+      ),
+    );
+  }
+
+  Widget _buildFormCard(ColorScheme colorScheme, TextTheme textTheme) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Nuevo registro',
+                style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 16),
+              _FormSection(
+                title: 'Hora del registro',
+                child: OutlinedButton.icon(
+                  onPressed: _pickTime,
+                  icon: const Icon(Icons.access_time_filled_rounded),
+                  label: Text(_formatTimeLabel(_selectedTime)),
+                ),
+              ),
+              const SizedBox(height: 16),
+              _FormSection(
+                title: 'Toma (ml)',
+                subtitle: 'Introduce los mililitros ingeridos si aplica.',
+                child: TextFormField(
+                  controller: _mlController,
+                  decoration: const InputDecoration(
+                    hintText: 'Ej. 120',
+                  ),
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return null;
+                    }
+                    final parsed = int.tryParse(value.trim());
+                    if (parsed == null) {
+                      return 'Introduce solo números';
+                    }
+                    if (parsed < 0) {
+                      return 'El valor no puede ser negativo';
+                    }
+                    return null;
+                  },
+                ),
+              ),
+              const SizedBox(height: 16),
+              SwitchListTile.adaptive(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('¿Ha hecho caca?'),
+                value: _didPoop,
+                onChanged: (value) => setState(() => _didPoop = value),
+              ),
+              const SizedBox(height: 8),
+              SwitchListTile.adaptive(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('¿Le hemos duchado?'),
+                value: _showered,
+                onChanged: (value) => setState(() => _showered = value),
+              ),
+              const SizedBox(height: 16),
+              _FormSection(
+                title: 'Notas',
+                subtitle: 'Escribe cualquier observación adicional.',
+                child: TextFormField(
+                  controller: _notesController,
+                  minLines: 3,
+                  maxLines: 5,
+                  decoration: const InputDecoration(hintText: 'Ej. Durmió muy bien.'),
+                ),
+              ),
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                onPressed: _isSaving ? null : _saveLog,
+                icon: _isSaving
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.save_rounded),
+                label: Text(_isSaving ? 'Guardando...' : 'Guardar registro'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLogsSection(ColorScheme colorScheme, TextTheme textTheme) {
+    if (_isLoadingLogs) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_logs.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(color: colorScheme.outlineVariant),
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.hourglass_empty_rounded, color: colorScheme.outline),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                'Aún no hay registros para este día. ¡Empieza añadiendo uno!',
+                style: textTheme.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      children: _logs
+          .map((log) => Padding(
+                padding: const EdgeInsets.only(bottom: 16),
+                child: _DailyLogCard(log: log, colorScheme: colorScheme, textTheme: textTheme),
+              ))
+          .toList(),
+    );
+  }
+}
+
+class _DayNavigator extends StatelessWidget {
+  const _DayNavigator({
+    required this.dayLabel,
+    required this.onPrevious,
+    required this.onNext,
+    required this.colorScheme,
+  });
+
+  final String dayLabel;
+  final VoidCallback onPrevious;
+  final VoidCallback onNext;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        gradient: LinearGradient(
+          colors: [
+            colorScheme.primary.withOpacity(0.12),
+            Colors.white,
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          _CircleButton(icon: Icons.chevron_left, onPressed: onPrevious),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              dayLabel,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ),
+          const SizedBox(width: 16),
+          _CircleButton(icon: Icons.chevron_right, onPressed: onNext),
+        ],
+      ),
+    );
+  }
+}
+
+class _CircleButton extends StatelessWidget {
+  const _CircleButton({required this.icon, required this.onPressed});
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      shape: const CircleBorder(),
+      color: Colors.white,
+      child: InkWell(
+        onTap: onPressed,
+        customBorder: const CircleBorder(),
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Icon(icon, size: 26),
+        ),
+      ),
+    );
+  }
+}
+
+class _FormSection extends StatelessWidget {
+  const _FormSection({required this.title, this.subtitle, required this.child});
+
+  final String title;
+  final String? subtitle;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        if (subtitle != null) ...[
+          const SizedBox(height: 4),
+          Text(
+            subtitle!,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey[600]),
+          ),
+        ],
+        const SizedBox(height: 8),
+        child,
+      ],
+    );
+  }
+}
+
+class _DailyLogCard extends StatelessWidget {
+  const _DailyLogCard({required this.log, required this.colorScheme, required this.textTheme});
+
+  final BabyDailyLog log;
+  final ColorScheme colorScheme;
+  final TextTheme textTheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final chips = <Widget>[];
+    if (log.intakeMl != null) {
+      chips.add(_InfoChip(
+        icon: Icons.local_drink_rounded,
+        label: 'Toma: ${log.intakeMl} ml',
+        color: colorScheme.primary,
+      ));
+    }
+    if (log.didPoop) {
+      chips.add(_InfoChip(
+        icon: Icons.baby_changing_station_rounded,
+        label: 'Pañal sucio',
+        color: colorScheme.secondary,
+      ));
+    }
+    if (log.showered) {
+      chips.add(_InfoChip(
+        icon: Icons.shower_rounded,
+        label: 'Ducha',
+        color: colorScheme.tertiary,
+      ));
+    }
+
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      elevation: 1,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: colorScheme.primary.withOpacity(0.12),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(Icons.schedule_rounded, color: colorScheme.primary),
+                ),
+                const SizedBox(width: 16),
+                Text(
+                  DateFormat('HH:mm').format(log.loggedAt),
+                  style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (chips.isNotEmpty)
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: chips,
+              ),
+            if (log.notes != null && log.notes!.isNotEmpty) ...[
+              if (chips.isNotEmpty) const SizedBox(height: 16),
+              Text(
+                log.notes!,
+                style: textTheme.bodyMedium,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({required this.icon, required this.label, required this.color});
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        color: color.withOpacity(0.12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18, color: color),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:baby_track_app/features/baby/domain/models/baby.dart';
+import 'package:baby_track_app/features/baby/presentation/pages/baby_daily_log_page.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -91,6 +92,11 @@ class BabyMenuPage extends StatelessWidget {
           colorScheme.primary.withOpacity(0.18),
           colorScheme.primary.withOpacity(0.08),
         ],
+        onTap: () => Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => BabyDailyLogPage(baby: baby),
+          ),
+        ),
       ),
       _BabyActionCardData(
         title: 'HISTORIAL',
@@ -237,7 +243,8 @@ class BabyMenuPage extends StatelessWidget {
                                   width: cardWidth,
                                   child: _BabyActionCard(
                                     data: action,
-                                    onTap: () => _showComingSoon(context, action.title),
+                                    onTap: action.onTap ??
+                                        () => _showComingSoon(context, action.title),
                                   ),
                                 ),
                               )
@@ -534,6 +541,7 @@ class _BabyActionCardData {
     required this.icon,
     required this.accentColor,
     required this.backgroundColors,
+    this.onTap,
   });
 
   final String title;
@@ -541,6 +549,7 @@ class _BabyActionCardData {
   final IconData icon;
   final Color accentColor;
   final List<Color> backgroundColors;
+  final VoidCallback? onTap;
 }
 
 class _DecorativeBubble extends StatelessWidget {

--- a/baby_track_app/lib/shared/data/database/database_helper.dart
+++ b/baby_track_app/lib/shared/data/database/database_helper.dart
@@ -4,7 +4,7 @@ import 'package:sqflite/sqflite.dart';
 /// Sistema de migraciones siguiendo AGENTS.md
 class DatabaseHelper {
   static const String _databaseName = 'baby_track.db';
-  static const int _databaseVersion = 2; // Incrementado para migración
+  static const int _databaseVersion = 3; // Incrementado para nueva tabla de registros diarios
 
   static final DatabaseHelper _instance = DatabaseHelper._internal();
   static Database? _database;
@@ -30,9 +30,10 @@ class DatabaseHelper {
     );
   }
 
-  /// Creación inicial con estructura v2
+  /// Creación inicial con estructura v3
   Future<void> _onCreate(Database db, int version) async {
     await _createBabiesTableV2(db);
+    await _createBabyDailyLogsTable(db);
     await _createIndices(db);
   }
 
@@ -45,6 +46,11 @@ class DatabaseHelper {
       await _upgradeToV2(db);
     }
 
+    // Migración de v2 a v3: crear tabla baby_daily_logs
+    if (oldVersion < 3) {
+      await _upgradeToV3(db);
+    }
+
     // Futuras migraciones
     // if (oldVersion < 3) {
     //   await _upgradeToV3(db);
@@ -55,6 +61,8 @@ class DatabaseHelper {
   Future<void> _createIndices(Database db) async {
     await db.execute('CREATE INDEX IF NOT EXISTS idx_babies_name ON babies(name)');
     await db.execute('CREATE INDEX IF NOT EXISTS idx_babies_birth_date ON babies(birth_date)');
+    await db.execute(
+        'CREATE INDEX IF NOT EXISTS idx_baby_daily_logs_baby_day ON baby_daily_logs(baby_id, log_day)');
   }
 
   /// Tabla v2 (con gender)
@@ -68,6 +76,24 @@ class DatabaseHelper {
         photo_path TEXT,
         created_at INTEGER NOT NULL,
         updated_at INTEGER
+      )
+    ''');
+  }
+
+  Future<void> _createBabyDailyLogsTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE baby_daily_logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        baby_id INTEGER NOT NULL,
+        log_day INTEGER NOT NULL,
+        logged_at INTEGER NOT NULL,
+        intake_ml INTEGER,
+        did_poop INTEGER NOT NULL DEFAULT 0,
+        showered INTEGER NOT NULL DEFAULT 0,
+        notes TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER,
+        FOREIGN KEY (baby_id) REFERENCES babies(id) ON DELETE CASCADE
       )
     ''');
   }
@@ -87,6 +113,19 @@ class DatabaseHelper {
     } catch (e) {
       print('Error during v1 to v2 migration: $e');
       // En caso de error, registrar pero continuar
+      rethrow;
+    }
+  }
+
+  Future<void> _upgradeToV3(Database db) async {
+    try {
+      await _createBabyDailyLogsTable(db);
+      await db.execute(
+        'CREATE INDEX IF NOT EXISTS idx_baby_daily_logs_baby_day ON baby_daily_logs(baby_id, log_day)',
+      );
+      print('Successfully created baby_daily_logs table');
+    } catch (e) {
+      print('Error during v2 to v3 migration: $e');
       rethrow;
     }
   }


### PR DESCRIPTION
## Summary
- add a BabyDailyLog domain model and repository implementation to persist daily entries
- create the daily log page with day navigation, optional fields, and saved logs list
- update the database schema and baby menu to expose the new registration experience

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dd0695f7d88332a6557b04dabef6cf