### PR TITLE
feat: track vomiting events across baby views

### DIFF
--- a/baby_track_app/lib/features/baby/domain/models/baby_daily_log.dart
+++ b/baby_track_app/lib/features/baby/domain/models/baby_daily_log.dart
@@ -7,6 +7,7 @@ class BabyDailyLog {
     this.intakeMl,
     this.didPoop = false,
     this.showered = false,
+    this.vomited = false,
     this.notes,
     required this.createdAt,
     this.updatedAt,
@@ -19,6 +20,7 @@ class BabyDailyLog {
   final int? intakeMl;
   final bool didPoop;
   final bool showered;
+  final bool vomited;
   final String? notes;
   final DateTime createdAt;
   final DateTime? updatedAt;
@@ -31,6 +33,7 @@ class BabyDailyLog {
     int? intakeMl,
     bool? didPoop,
     bool? showered,
+    bool? vomited,
     String? notes,
     DateTime? createdAt,
     DateTime? updatedAt,
@@ -43,6 +46,7 @@ class BabyDailyLog {
       intakeMl: intakeMl ?? this.intakeMl,
       didPoop: didPoop ?? this.didPoop,
       showered: showered ?? this.showered,
+      vomited: vomited ?? this.vomited,
       notes: notes ?? this.notes,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
@@ -58,6 +62,7 @@ class BabyDailyLog {
       'intake_ml': intakeMl,
       'did_poop': didPoop ? 1 : 0,
       'showered': showered ? 1 : 0,
+      'vomited': vomited ? 1 : 0,
       'notes': notes,
       'created_at': createdAt.millisecondsSinceEpoch,
       'updated_at': updatedAt?.millisecondsSinceEpoch,
@@ -73,6 +78,7 @@ class BabyDailyLog {
       intakeMl: json['intake_ml'] as int?,
       didPoop: (json['did_poop'] as int) == 1,
       showered: (json['showered'] as int) == 1,
+      vomited: (json['vomited'] as int?) == 1,
       notes: json['notes'] as String?,
       createdAt: DateTime.fromMillisecondsSinceEpoch(json['created_at'] as int),
       updatedAt: json['updated_at'] != null

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_daily_log_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_daily_log_page.dart
@@ -24,6 +24,7 @@ class _BabyDailyLogPageState extends State<BabyDailyLogPage> {
   TimeOfDay _selectedTime = TimeOfDay.now();
   bool _didPoop = false;
   bool _showered = false;
+  bool _vomited = false;
   bool _isSaving = false;
   bool _isLoadingLogs = false;
   List<BabyDailyLog> _logs = const [];
@@ -134,6 +135,7 @@ class _BabyDailyLogPageState extends State<BabyDailyLogPage> {
       intakeMl: intakeText.isEmpty ? null : int.parse(intakeText),
       didPoop: _didPoop,
       showered: _showered,
+      vomited: _vomited,
       notes: notesText.isEmpty ? null : notesText,
       createdAt: DateTime.now(),
     );
@@ -186,6 +188,7 @@ class _BabyDailyLogPageState extends State<BabyDailyLogPage> {
       _notesController.clear();
       _didPoop = false;
       _showered = false;
+      _vomited = false;
       _selectedTime = TimeOfDay.now();
     });
   }
@@ -304,6 +307,13 @@ class _BabyDailyLogPageState extends State<BabyDailyLogPage> {
                 title: const Text('¿Ha hecho caca?'),
                 value: _didPoop,
                 onChanged: (value) => setState(() => _didPoop = value),
+              ),
+              const SizedBox(height: 8),
+              SwitchListTile.adaptive(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('¿Ha vomitado?'),
+                value: _vomited,
+                onChanged: (value) => setState(() => _vomited = value),
               ),
               const SizedBox(height: 8),
               SwitchListTile.adaptive(
@@ -509,6 +519,13 @@ class _DailyLogCard extends StatelessWidget {
         icon: Icons.shower_rounded,
         label: 'Ducha',
         color: colorScheme.tertiary,
+      ));
+    }
+    if (log.vomited) {
+      chips.add(_InfoChip(
+        icon: Icons.sick_rounded,
+        label: 'Vómito',
+        color: colorScheme.error,
       ));
     }
 

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
@@ -203,28 +203,24 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
     final actions = [
       _BabyActionCardData(
         title: 'Registro',
-        description: 'Añade tomas, pañales y notas del día a día.',
         icon: Icons.edit_note_rounded,
         accentColor: colorScheme.primary,
-        backgroundColors: [
-          colorScheme.primary.withOpacity(0.18),
-          colorScheme.primary.withOpacity(0.08),
-        ],
-        onTap: () => Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => BabyDailyLogPage(baby: baby),
-          ),
-        ),
+        onTap: () async {
+          await Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => BabyDailyLogPage(baby: baby),
+            ),
+          );
+          if (!mounted) {
+            return;
+          }
+          await _loadStats();
+        },
       ),
       _BabyActionCardData(
         title: 'Historial',
-        description: 'Pronto podrás consultar el historial completo.',
         icon: Icons.history_rounded,
         accentColor: colorScheme.secondary,
-        backgroundColors: [
-          colorScheme.secondary.withOpacity(0.18),
-          colorScheme.secondary.withOpacity(0.08),
-        ],
       ),
     ];
 
@@ -388,6 +384,7 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
 
     final lastIntake = _findLastLog((log) => (log.intakeMl ?? 0) > 0);
     final lastPoop = _findLastLog((log) => log.didPoop);
+    final lastVomit = _findLastLog((log) => log.vomited);
     final lastShower = _findLastLog((log) => log.showered);
 
     String? intakeDetail;
@@ -400,6 +397,7 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
     final feedCount = todayIntakes.length;
     final totalIntake = todayIntakes.fold<int>(0, (sum, log) => sum + (log.intakeMl ?? 0));
     final poopCount = _todayLogs.where((log) => log.didPoop).length;
+    final vomitCount = _todayLogs.where((log) => log.vomited).length;
     final showerCount = _todayLogs.where((log) => log.showered).length;
 
     return Column(
@@ -420,6 +418,13 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
               iconColor: colorScheme.secondary,
               title: 'Pañales',
               subtitle: _formatEventSubtitle(lastPoop),
+            ),
+            const SizedBox(height: 12),
+            _BabyStatTile(
+              icon: Icons.sick_rounded,
+              iconColor: colorScheme.error,
+              title: 'Vómito',
+              subtitle: _formatEventSubtitle(lastVomit),
             ),
             const SizedBox(height: 12),
             _BabyStatTile(
@@ -450,6 +455,15 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
               subtitle: poopCount == 0
                   ? 'Sin pañales registrados por ahora.'
                   : _formatCountLabel(poopCount, singular: 'vez', plural: 'veces'),
+            ),
+            const SizedBox(height: 12),
+            _BabyStatTile(
+              icon: Icons.sick_rounded,
+              iconColor: colorScheme.error,
+              title: 'Vómitos',
+              subtitle: vomitCount == 0
+                  ? 'Sin vómitos registrados hoy.'
+                  : _formatCountLabel(vomitCount, singular: 'vez', plural: 'veces'),
             ),
             const SizedBox(height: 12),
             _BabyStatTile(
@@ -670,6 +684,12 @@ class _BabyActionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final surfaceVariant = colorScheme.surfaceVariant;
+    final baseColor = Color.alphaBlend(Colors.black.withOpacity(0.22), surfaceVariant);
+    final gradientColors = [
+      Color.alphaBlend(data.accentColor.withOpacity(0.18), baseColor),
+      Color.alphaBlend(data.accentColor.withOpacity(0.08), baseColor),
+    ];
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(24),
@@ -677,7 +697,7 @@ class _BabyActionCard extends StatelessWidget {
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(24),
           gradient: LinearGradient(
-            colors: data.backgroundColors,
+            colors: gradientColors,
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
           ),
@@ -712,13 +732,15 @@ class _BabyActionCard extends StatelessWidget {
                   fontWeight: FontWeight.w700,
                 ),
               ),
-              const SizedBox(height: 6),
-              Text(
-                data.description,
-                style: theme.textTheme.bodySmall?.copyWith(height: 1.4),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
+              if (data.description != null && data.description!.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                Text(
+                  data.description!,
+                  style: theme.textTheme.bodySmall?.copyWith(height: 1.4),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
             ],
           ),
         ),
@@ -823,18 +845,16 @@ class _BabyStatTile extends StatelessWidget {
 class _BabyActionCardData {
   const _BabyActionCardData({
     required this.title,
-    required this.description,
+    this.description,
     required this.icon,
     required this.accentColor,
-    required this.backgroundColors,
     this.onTap,
   });
 
   final String title;
-  final String description;
+  final String? description;
   final IconData icon;
   final Color accentColor;
-  final List<Color> backgroundColors;
   final VoidCallback? onTap;
 }
 

--- a/baby_track_app/lib/shared/data/database/database_helper.dart
+++ b/baby_track_app/lib/shared/data/database/database_helper.dart
@@ -4,7 +4,7 @@ import 'package:sqflite/sqflite.dart';
 /// Sistema de migraciones siguiendo AGENTS.md
 class DatabaseHelper {
   static const String _databaseName = 'baby_track.db';
-  static const int _databaseVersion = 3; // Incrementado para nueva tabla de registros diarios
+  static const int _databaseVersion = 4; // Incrementado para columna de vómito en registros diarios
 
   static final DatabaseHelper _instance = DatabaseHelper._internal();
   static Database? _database;
@@ -51,6 +51,11 @@ class DatabaseHelper {
       await _upgradeToV3(db);
     }
 
+    // Migración de v3 a v4: agregar columna vomited
+    if (oldVersion < 4) {
+      await _upgradeToV4(db);
+    }
+
     // Futuras migraciones
     // if (oldVersion < 3) {
     //   await _upgradeToV3(db);
@@ -90,6 +95,7 @@ class DatabaseHelper {
         intake_ml INTEGER,
         did_poop INTEGER NOT NULL DEFAULT 0,
         showered INTEGER NOT NULL DEFAULT 0,
+        vomited INTEGER NOT NULL DEFAULT 0,
         notes TEXT,
         created_at INTEGER NOT NULL,
         updated_at INTEGER,
@@ -126,6 +132,22 @@ class DatabaseHelper {
       print('Successfully created baby_daily_logs table');
     } catch (e) {
       print('Error during v2 to v3 migration: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> _upgradeToV4(Database db) async {
+    try {
+      final columns = await db.rawQuery('PRAGMA table_info(baby_daily_logs)');
+      final hasVomited = columns.any((col) => col['name'] == 'vomited');
+      if (!hasVomited) {
+        await db.execute(
+          'ALTER TABLE baby_daily_logs ADD COLUMN vomited INTEGER NOT NULL DEFAULT 0',
+        );
+        print('Successfully added vomited column to baby_daily_logs table');
+      }
+    } catch (e) {
+      print('Error during v3 to v4 migration: $e');
       rethrow;
     }
   }


### PR DESCRIPTION
## Summary
- add vomit support to baby daily logs, including model and database migration
- expose vomit switches and chips in the daily log UI and recent activity cards
- darken Registro/Historial action cards and remove their descriptive text for clearer affordance

## Testing
- not run (Flutter SDK unavailable in container)

## Responsable
- Agente responsable: Agente UI/UX

------
https://chatgpt.com/codex/tasks/task_b_68dd58d5d8f48332b7d35567aefda428