### PR TITLE
feat: redesign baby history timeline and quick actions

### DIFF
--- a/baby_track_app/lib/features/baby/presentation/pages/baby_history_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_history_page.dart
@@ -233,9 +233,11 @@ class _BabyHistoryPageState extends State<BabyHistoryPage> {
 
     return RefreshIndicator(
       onRefresh: _loadAllLogs,
-      child: ListView.builder(
-        padding: const EdgeInsets.all(20),
+      child: ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
         itemCount: sortedDays.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 16),
         itemBuilder: (context, index) {
           final dayKey = sortedDays[index];
           final dayLogs = _groupedLogs[dayKey]!;
@@ -251,179 +253,419 @@ class _BabyHistoryPageState extends State<BabyHistoryPage> {
     ColorScheme colorScheme,
     TextTheme textTheme,
   ) {
-    final totalMl = dayLogs.fold<int>(0, (sum, log) => sum + (log.intakeMl ?? 0));
-    final avgMl = dayLogs.isNotEmpty ? (totalMl / dayLogs.length).round() : 0;
+    final feedLogs = dayLogs.where((log) => (log.intakeMl ?? 0) > 0).toList();
+    final totalMl = feedLogs.fold<int>(0, (sum, log) => sum + (log.intakeMl ?? 0));
+    final diaperCount = dayLogs.where((log) => log.didPoop).length;
+    final vomitCount = dayLogs.where((log) => log.vomited).length;
+    final showerCount = dayLogs.where((log) => log.showered).length;
+    final notesCount = dayLogs.where((log) => log.notes?.isNotEmpty == true).length;
+
+    final summaryChips = <Widget>[
+      _buildSummaryChip(
+        icon: Icons.event_note_rounded,
+        label: _pluralize(dayLogs.length, singular: 'registro', plural: 'registros'),
+        color: colorScheme.primary,
+        colorScheme: colorScheme,
+        textTheme: textTheme,
+      ),
+      if (feedLogs.isNotEmpty)
+        _buildSummaryChip(
+          icon: Icons.local_drink_rounded,
+          label:
+              '${_pluralize(feedLogs.length, singular: 'toma', plural: 'tomas')} · ${totalMl} ml',
+          color: colorScheme.primary,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+      if (diaperCount > 0)
+        _buildSummaryChip(
+          icon: Icons.baby_changing_station_rounded,
+          label:
+              _pluralize(diaperCount, singular: 'pañal sucio', plural: 'pañales sucios'),
+          color: colorScheme.secondary,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+      if (showerCount > 0)
+        _buildSummaryChip(
+          icon: Icons.bathtub_rounded,
+          label: _pluralize(showerCount, singular: 'baño', plural: 'baños'),
+          color: colorScheme.tertiary,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+      if (vomitCount > 0)
+        _buildSummaryChip(
+          icon: Icons.sick_rounded,
+          label: _pluralize(vomitCount, singular: 'vómito', plural: 'vómitos'),
+          color: colorScheme.error,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+      if (notesCount > 0)
+        _buildSummaryChip(
+          icon: Icons.sticky_note_2_rounded,
+          label: _pluralize(notesCount, singular: 'nota', plural: 'notas'),
+          color: colorScheme.outline,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+    ];
+
+    final timelineLogs = [...dayLogs]
+      ..sort((a, b) => b.loggedAt.compareTo(a.loggedAt));
 
     return Container(
-      margin: const EdgeInsets.only(bottom: 24),
       decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(20),
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.35)),
         boxShadow: [
           BoxShadow(
-            color: colorScheme.primary.withOpacity(0.08),
-            blurRadius: 16,
-            offset: const Offset(0, 4),
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 18,
+            offset: const Offset(0, 12),
           ),
         ],
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Header del día
-          Container(
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [
-                  colorScheme.primary.withOpacity(0.1),
-                  colorScheme.secondary.withOpacity(0.05),
-                ],
-              ),
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(20),
-                topRight: Radius.circular(20),
-              ),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
               children: [
-                Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                        color: colorScheme.primary,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: const Icon(Icons.calendar_today, color: Colors.white, size: 18),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Text(
+                Container(
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: colorScheme.primary.withOpacity(0.12),
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: Icon(
+                    Icons.calendar_today_rounded,
+                    color: colorScheme.primary,
+                    size: 18,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
                         _formatDayHeader(dayKey),
                         style: textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.w700,
                           color: colorScheme.onSurface,
                         ),
                       ),
-                    ),
-                    Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                      decoration: BoxDecoration(
-                        color: colorScheme.primary.withOpacity(0.2),
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: Text(
-                        '${dayLogs.length} registro${dayLogs.length != 1 ? 's' : ''}',
-                        style: textTheme.bodySmall?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: colorScheme.primary,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                if (totalMl > 0) ...[
-                  const SizedBox(height: 12),
-                  Row(
-                    children: [
-                      Icon(Icons.local_drink, size: 16, color: colorScheme.primary),
-                      const SizedBox(width: 8),
                       Text(
-                        'Total: ${totalMl}ml • Promedio: ${avgMl}ml',
+                        DateFormat('d MMM yyyy', 'es').format(DateTime.parse(dayKey)),
                         style: textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurface.withOpacity(0.7),
+                          color: colorScheme.onSurface.withOpacity(0.6),
+                          fontWeight: FontWeight.w500,
                         ),
                       ),
                     ],
                   ),
-                ],
+                ),
               ],
             ),
+            if (summaryChips.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: summaryChips,
+              ),
+            ],
+            const SizedBox(height: 20),
+            ...List.generate(timelineLogs.length, (index) {
+              final log = timelineLogs[index];
+              final isLast = index == timelineLogs.length - 1;
+              return _buildTimelineEntry(log, isLast, colorScheme, textTheme);
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTimelineEntry(
+    BabyDailyLog log,
+    bool isLast,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    final indicatorColor = _timelineColor(log, colorScheme);
+    final eventChips = _buildEventChips(log, colorScheme, textTheme);
+    final notes = log.notes;
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: isLast ? 0 : 16),
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SizedBox(
+              width: 28,
+              child: Column(
+                children: [
+                  Container(
+                    width: 12,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      color: indicatorColor,
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: indicatorColor.withOpacity(0.3),
+                          blurRadius: 8,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (!isLast)
+                    Expanded(
+                      child: Container(
+                        width: 2,
+                        margin: const EdgeInsets.symmetric(vertical: 4),
+                        decoration: BoxDecoration(
+                          color: colorScheme.outlineVariant.withOpacity(0.4),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceVariant.withOpacity(0.35),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.4)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.schedule_rounded,
+                          size: 16,
+                          color: colorScheme.onSurface.withOpacity(0.6),
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          DateFormat('HH:mm').format(log.loggedAt),
+                          style: textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: colorScheme.onSurface,
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (eventChips.isNotEmpty) ...[
+                      const SizedBox(height: 12),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: eventChips,
+                      ),
+                    ],
+                    if (eventChips.isEmpty && (notes?.isNotEmpty != true)) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        'Registro sin detalles adicionales.',
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurface.withOpacity(0.6),
+                        ),
+                      ),
+                    ],
+                    if (notes?.isNotEmpty == true) ...[
+                      const SizedBox(height: 12),
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: colorScheme.surface.withOpacity(0.9),
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                            color: colorScheme.outlineVariant.withOpacity(0.3),
+                          ),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Icon(
+                              Icons.sticky_note_2_rounded,
+                              size: 16,
+                              color: colorScheme.onSurface.withOpacity(0.6),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                notes!,
+                                style: textTheme.bodySmall?.copyWith(
+                                  color: colorScheme.onSurface.withOpacity(0.75),
+                                  height: 1.4,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildEventChips(
+    BabyDailyLog log,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    final chips = <Widget>[];
+    final intake = log.intakeMl ?? 0;
+
+    if (intake > 0) {
+      chips.add(
+        _buildEventChip(
+          icon: Icons.local_drink_rounded,
+          label: '${intake} ml',
+          color: colorScheme.primary,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+      );
+    }
+    if (log.didPoop) {
+      chips.add(
+        _buildEventChip(
+          icon: Icons.baby_changing_station_rounded,
+          label: 'Pañal sucio',
+          color: colorScheme.secondary,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+      );
+    }
+    if (log.showered) {
+      chips.add(
+        _buildEventChip(
+          icon: Icons.bathtub_rounded,
+          label: 'Baño',
+          color: colorScheme.tertiary,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+      );
+    }
+    if (log.vomited) {
+      chips.add(
+        _buildEventChip(
+          icon: Icons.sick_rounded,
+          label: 'Vómito',
+          color: colorScheme.error,
+          colorScheme: colorScheme,
+          textTheme: textTheme,
+        ),
+      );
+    }
+
+    return chips;
+  }
+
+  Widget _buildSummaryChip({
+    required IconData icon,
+    required String label,
+    required Color color,
+    required ColorScheme colorScheme,
+    required TextTheme textTheme,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: color.withOpacity(0.2)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: textTheme.bodySmall?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: colorScheme.onSurface.withOpacity(0.75),
+            ),
           ),
-          // Lista de registros del día
-          ...dayLogs.asMap().entries.map((entry) {
-            final index = entry.key;
-            final log = entry.value;
-            final isLast = index == dayLogs.length - 1;
-            return _buildLogItem(log, colorScheme, textTheme, isLast);
-          }),
         ],
       ),
     );
   }
 
-  Widget _buildLogItem(
-    BabyDailyLog log,
-    ColorScheme colorScheme,
-    TextTheme textTheme,
-    bool isLast,
-  ) {
+  Widget _buildEventChip({
+    required IconData icon,
+    required String label,
+    required Color color,
+    required ColorScheme colorScheme,
+    required TextTheme textTheme,
+  }) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
-        border: !isLast
-            ? Border(
-                bottom: BorderSide(color: colorScheme.outlineVariant.withOpacity(0.3), width: 1),
-              )
-            : null,
+        color: color.withOpacity(0.14),
+        borderRadius: BorderRadius.circular(16),
       ),
       child: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              color: colorScheme.primaryContainer,
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Icon(Icons.access_time, color: colorScheme.onPrimaryContainer, size: 20),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  DateFormat('HH:mm').format(log.loggedAt),
-                  style: textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: colorScheme.onSurface,
-                  ),
-                ),
-                if (log.intakeMl != null && log.intakeMl! > 0) ...[
-                  const SizedBox(height: 4),
-                  Row(
-                    children: [
-                      Icon(Icons.local_drink, size: 14, color: colorScheme.primary),
-                      const SizedBox(width: 4),
-                      Text(
-                        '${log.intakeMl} ml',
-                        style: textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurface.withOpacity(0.7),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-                if (log.notes?.isNotEmpty == true) ...[
-                  const SizedBox(height: 4),
-                  Text(
-                    log.notes!,
-                    style: textTheme.bodySmall?.copyWith(
-                      color: colorScheme.onSurface.withOpacity(0.6),
-                      fontStyle: FontStyle.italic,
-                    ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ],
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: textTheme.bodySmall?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: colorScheme.onSurface.withOpacity(0.8),
             ),
           ),
         ],
       ),
     );
+  }
+
+  String _pluralize(
+    int count, {
+    required String singular,
+    required String plural,
+  }) {
+    return '$count ${count == 1 ? singular : plural}';
+  }
+
+  Color _timelineColor(BabyDailyLog log, ColorScheme colorScheme) {
+    if (log.vomited) {
+      return colorScheme.error;
+    }
+    if (log.didPoop) {
+      return colorScheme.secondary;
+    }
+    if (log.showered) {
+      return colorScheme.tertiary;
+    }
+    if ((log.intakeMl ?? 0) > 0) {
+      return colorScheme.primary;
+    }
+    return colorScheme.outline;
   }
 }

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
@@ -4,6 +4,7 @@ import 'package:baby_track_app/features/baby/domain/models/baby.dart';
 import 'package:baby_track_app/features/baby/domain/models/baby_daily_log.dart';
 import 'package:baby_track_app/features/baby/infrastructure/baby_daily_log_repository_impl.dart';
 import 'package:baby_track_app/features/baby/presentation/pages/baby_daily_log_page.dart';
+import 'package:baby_track_app/features/baby/presentation/pages/baby_history_page.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -18,7 +19,6 @@ class BabyMenuPage extends StatefulWidget {
 
 class _BabyMenuPageState extends State<BabyMenuPage> {
   final BabyDailyLogRepositoryImpl _dailyLogRepository = BabyDailyLogRepositoryImpl();
-  final PageController _actionPageController = PageController(viewportFraction: 0.72);
 
   bool _isLoadingStats = false;
   List<BabyDailyLog> _todayLogs = const [];
@@ -28,12 +28,6 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
   void initState() {
     super.initState();
     _loadStats();
-  }
-
-  @override
-  void dispose() {
-    _actionPageController.dispose();
-    super.dispose();
   }
 
   Future<void> _loadStats() async {
@@ -121,17 +115,6 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
     }
   }
 
-  void _showComingSoon(BuildContext context, String featureName) {
-    ScaffoldMessenger.of(context)
-      ..hideCurrentSnackBar()
-      ..showSnackBar(
-        SnackBar(
-          content: Text('$featureName estará disponible muy pronto.'),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
-  }
-
   BabyDailyLog? _findLastLog(bool Function(BabyDailyLog) predicate) {
     for (final log in _recentLogs) {
       if (predicate(log)) {
@@ -199,30 +182,6 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
     final baby = widget.baby;
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-
-    final actions = [
-      _BabyActionCardData(
-        title: 'Registro',
-        icon: Icons.edit_note_rounded,
-        accentColor: colorScheme.primary,
-        onTap: () async {
-          await Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => BabyDailyLogPage(baby: baby),
-            ),
-          );
-          if (!mounted) {
-            return;
-          }
-          await _loadStats();
-        },
-      ),
-      _BabyActionCardData(
-        title: 'Historial',
-        icon: Icons.history_rounded,
-        accentColor: colorScheme.secondary,
-      ),
-    ];
 
     return Scaffold(
       backgroundColor: colorScheme.surface,
@@ -331,12 +290,26 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
                         genderColor: _genderColor(colorScheme),
                         ageLabel: _formatAge(),
                       ),
-                      const SizedBox(height: 28),
-                      _BabyActionCarousel(
-                        controller: _actionPageController,
-                        actions: actions,
-                        onUnavailableAction: (action) =>
-                            _showComingSoon(context, action.title),
+                      const SizedBox(height: 24),
+                      _BabyQuickActions(
+                        onCreateLog: () async {
+                          await Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => BabyDailyLogPage(baby: baby),
+                            ),
+                          );
+                          if (!mounted) {
+                            return;
+                          }
+                          await _loadStats();
+                        },
+                        onViewHistory: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => BabyHistoryPage(baby: baby),
+                            ),
+                          );
+                        },
                       ),
                       const SizedBox(height: 28),
                       _buildStatsSection(colorScheme, textTheme),
@@ -555,6 +528,99 @@ class _BabySummaryCard extends StatelessWidget {
   }
 }
 
+class _BabyQuickActions extends StatelessWidget {
+  const _BabyQuickActions({
+    required this.onCreateLog,
+    required this.onViewHistory,
+  });
+
+  final VoidCallback onCreateLog;
+  final VoidCallback onViewHistory;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Row(
+      children: [
+        Expanded(
+          child: _QuickActionButton(
+            icon: Icons.edit_note_rounded,
+            label: 'Registro',
+            color: colorScheme.primary,
+            onTap: onCreateLog,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: _QuickActionButton(
+            icon: Icons.history_rounded,
+            label: 'Historial',
+            color: colorScheme.secondary,
+            onTap: onViewHistory,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _QuickActionButton extends StatelessWidget {
+  const _QuickActionButton({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final background = color.withOpacity(0.12);
+    final borderColor = color.withOpacity(0.25);
+
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(18),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(18),
+        child: Ink(
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: borderColor),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: color, size: 22),
+              const SizedBox(width: 8),
+              Flexible(
+                child: Text(
+                  label,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _BabyAvatar extends StatelessWidget {
   const _BabyAvatar({
     required this.baby,
@@ -631,119 +697,6 @@ class _InfoPill extends StatelessWidget {
                 ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _BabyActionCarousel extends StatelessWidget {
-  const _BabyActionCarousel({
-    required this.actions,
-    required this.controller,
-    required this.onUnavailableAction,
-  });
-
-  final List<_BabyActionCardData> actions;
-  final PageController controller;
-  final void Function(_BabyActionCardData action) onUnavailableAction;
-
-  @override
-  Widget build(BuildContext context) {
-    if (actions.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    return SizedBox(
-      height: 180,
-      child: PageView.builder(
-        controller: controller,
-        padEnds: false,
-        itemCount: actions.length,
-        itemBuilder: (context, index) {
-          final action = actions[index];
-          return Padding(
-            padding: EdgeInsets.only(right: index == actions.length - 1 ? 0 : 16),
-            child: _BabyActionCard(
-              data: action,
-              onTap: action.onTap ?? () => onUnavailableAction(action),
-            ),
-          );
-        },
-      ),
-    );
-  }
-}
-
-class _BabyActionCard extends StatelessWidget {
-  const _BabyActionCard({required this.data, required this.onTap});
-
-  final _BabyActionCardData data;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final surfaceVariant = colorScheme.surfaceVariant;
-    final baseColor = Color.alphaBlend(Colors.black.withOpacity(0.22), surfaceVariant);
-    final gradientColors = [
-      Color.alphaBlend(data.accentColor.withOpacity(0.18), baseColor),
-      Color.alphaBlend(data.accentColor.withOpacity(0.08), baseColor),
-    ];
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(24),
-      child: Ink(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(24),
-          gradient: LinearGradient(
-            colors: gradientColors,
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-          border: Border.all(
-            color: colorScheme.outlineVariant.withOpacity(0.6),
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.06),
-              blurRadius: 20,
-              offset: const Offset(0, 12),
-            ),
-          ],
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: data.accentColor.withOpacity(0.16),
-                  shape: BoxShape.circle,
-                ),
-                child: Icon(data.icon, color: data.accentColor, size: 26),
-              ),
-              const Spacer(),
-              Text(
-                data.title,
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              if (data.description != null && data.description!.isNotEmpty) ...[
-                const SizedBox(height: 6),
-                Text(
-                  data.description!,
-                  style: theme.textTheme.bodySmall?.copyWith(height: 1.4),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ],
-          ),
-        ),
       ),
     );
   }
@@ -840,22 +793,6 @@ class _BabyStatTile extends StatelessWidget {
       ],
     );
   }
-}
-
-class _BabyActionCardData {
-  const _BabyActionCardData({
-    required this.title,
-    this.description,
-    required this.icon,
-    required this.accentColor,
-    this.onTap,
-  });
-
-  final String title;
-  final String? description;
-  final IconData icon;
-  final Color accentColor;
-  final VoidCallback? onTap;
 }
 
 class _DecorativeBubble extends StatelessWidget {


### PR DESCRIPTION
**Agente responsable:** UI/UX

## Summary
- Reworked the baby history page into a day-based timeline with resumen chips y tarjetas de notas para revisar los registros de un vistazo.【F:lib/features/baby/presentation/pages/baby_history_page.dart†L230-L670】
- Sustituí el carrusel de acciones por botones rápidos minimalistas que navegan al registro y al nuevo historial del bebé.【F:lib/features/baby/presentation/pages/baby_menu_page.dart†L294-L316】【F:lib/features/baby/presentation/pages/baby_menu_page.dart†L546-L610】

## Testing
- No se pudieron ejecutar pruebas porque el SDK de Flutter no está disponible en el entorno de ejecución.

## Checklist
- [x] PR tiene **agente responsable** asignado.
- [ ] Pasa `analyze`, `format`, linters y tests.
- [ ] Incluye **screenshots**/goldens de UI actualizados.
- [ ] Estados de **error/vacío/loading** cubiertos.
- [ ] **Accesibilidad** revisada (labels, contraste, focus).
- [ ] **i18n** aplicado a las nuevas cadenas.
- [ ] **Telemetry** detrás de flags; sin PII.
- [ ] Documentación y ADR actualizados si aplica.

------
https://chatgpt.com/codex/tasks/task_b_68dd8a58d7008332a40ac87eb72a79a3