### PR TITLE
feat: add growth tracking view and upcoming stats enhancements

### DIFF
--- a/baby_track_app/lib/features/baby/domain/models/baby_growth_record.dart
+++ b/baby_track_app/lib/features/baby/domain/models/baby_growth_record.dart
@@ -1,0 +1,92 @@
+class BabyGrowthRecord {
+  const BabyGrowthRecord({
+    this.id,
+    required this.babyId,
+    required this.recordedAt,
+    this.heightCm,
+    this.weightKg,
+    this.headCircumferenceCm,
+    this.heightPercentile,
+    this.weightPercentile,
+    this.headCircumferencePercentile,
+    required this.createdAt,
+    this.updatedAt,
+  });
+
+  final int? id;
+  final int babyId;
+  final DateTime recordedAt;
+  final double? heightCm;
+  final double? weightKg;
+  final double? headCircumferenceCm;
+  final double? heightPercentile;
+  final double? weightPercentile;
+  final double? headCircumferencePercentile;
+  final DateTime createdAt;
+  final DateTime? updatedAt;
+
+  BabyGrowthRecord copyWith({
+    int? id,
+    int? babyId,
+    DateTime? recordedAt,
+    double? heightCm,
+    double? weightKg,
+    double? headCircumferenceCm,
+    double? heightPercentile,
+    double? weightPercentile,
+    double? headCircumferencePercentile,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return BabyGrowthRecord(
+      id: id ?? this.id,
+      babyId: babyId ?? this.babyId,
+      recordedAt: recordedAt ?? this.recordedAt,
+      heightCm: heightCm ?? this.heightCm,
+      weightKg: weightKg ?? this.weightKg,
+      headCircumferenceCm: headCircumferenceCm ?? this.headCircumferenceCm,
+      heightPercentile: heightPercentile ?? this.heightPercentile,
+      weightPercentile: weightPercentile ?? this.weightPercentile,
+      headCircumferencePercentile:
+          headCircumferencePercentile ?? this.headCircumferencePercentile,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'baby_id': babyId,
+      'recorded_at': recordedAt.millisecondsSinceEpoch,
+      'height_cm': heightCm,
+      'weight_kg': weightKg,
+      'head_circumference_cm': headCircumferenceCm,
+      'height_percentile': heightPercentile,
+      'weight_percentile': weightPercentile,
+      'head_circumference_percentile': headCircumferencePercentile,
+      'created_at': createdAt.millisecondsSinceEpoch,
+      'updated_at': updatedAt?.millisecondsSinceEpoch,
+    };
+  }
+
+  factory BabyGrowthRecord.fromJson(Map<String, dynamic> json) {
+    return BabyGrowthRecord(
+      id: json['id'] as int?,
+      babyId: json['baby_id'] as int,
+      recordedAt: DateTime.fromMillisecondsSinceEpoch(json['recorded_at'] as int),
+      heightCm: (json['height_cm'] as num?)?.toDouble(),
+      weightKg: (json['weight_kg'] as num?)?.toDouble(),
+      headCircumferenceCm:
+          (json['head_circumference_cm'] as num?)?.toDouble(),
+      heightPercentile: (json['height_percentile'] as num?)?.toDouble(),
+      weightPercentile: (json['weight_percentile'] as num?)?.toDouble(),
+      headCircumferencePercentile:
+          (json['head_circumference_percentile'] as num?)?.toDouble(),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(json['created_at'] as int),
+      updatedAt: json['updated_at'] == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(json['updated_at'] as int),
+    );
+  }
+}

--- a/baby_track_app/lib/features/baby/domain/repositories/baby_growth_record_repository.dart
+++ b/baby_track_app/lib/features/baby/domain/repositories/baby_growth_record_repository.dart
@@ -1,0 +1,11 @@
+import 'package:baby_track_app/features/baby/domain/models/baby_growth_record.dart';
+
+abstract class BabyGrowthRecordRepository {
+  Future<List<BabyGrowthRecord>> getRecordsForBaby(int babyId);
+
+  Future<BabyGrowthRecord> createRecord(BabyGrowthRecord record);
+
+  Future<BabyGrowthRecord> updateRecord(BabyGrowthRecord record);
+
+  Future<void> deleteRecord(int id);
+}

--- a/baby_track_app/lib/features/baby/infrastructure/baby_growth_record_repository_impl.dart
+++ b/baby_track_app/lib/features/baby/infrastructure/baby_growth_record_repository_impl.dart
@@ -1,0 +1,56 @@
+import 'package:baby_track_app/features/baby/domain/models/baby_growth_record.dart';
+import 'package:baby_track_app/features/baby/domain/repositories/baby_growth_record_repository.dart';
+import 'package:baby_track_app/shared/data/database/database_helper.dart';
+
+class BabyGrowthRecordRepositoryImpl implements BabyGrowthRecordRepository {
+  BabyGrowthRecordRepositoryImpl({DatabaseHelper? databaseHelper})
+      : _databaseHelper = databaseHelper ?? DatabaseHelper();
+
+  final DatabaseHelper _databaseHelper;
+
+  @override
+  Future<BabyGrowthRecord> createRecord(BabyGrowthRecord record) async {
+    final db = await _databaseHelper.database;
+    final now = DateTime.now();
+    final recordToInsert = record.copyWith(createdAt: now, updatedAt: now);
+    final id = await db.insert(
+      'baby_growth_records',
+      recordToInsert.toJson()..remove('id'),
+    );
+    return recordToInsert.copyWith(id: id);
+  }
+
+  @override
+  Future<void> deleteRecord(int id) async {
+    final db = await _databaseHelper.database;
+    await db.delete('baby_growth_records', where: 'id = ?', whereArgs: [id]);
+  }
+
+  @override
+  Future<List<BabyGrowthRecord>> getRecordsForBaby(int babyId) async {
+    final db = await _databaseHelper.database;
+    final result = await db.query(
+      'baby_growth_records',
+      where: 'baby_id = ?',
+      whereArgs: [babyId],
+      orderBy: 'recorded_at DESC',
+    );
+    return result.map(BabyGrowthRecord.fromJson).toList(growable: false);
+  }
+
+  @override
+  Future<BabyGrowthRecord> updateRecord(BabyGrowthRecord record) async {
+    if (record.id == null) {
+      throw ArgumentError('Cannot update record without id');
+    }
+    final db = await _databaseHelper.database;
+    final updated = record.copyWith(updatedAt: DateTime.now());
+    await db.update(
+      'baby_growth_records',
+      updated.toJson(),
+      where: 'id = ?',
+      whereArgs: [record.id],
+    );
+    return updated;
+  }
+}

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_growth_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_growth_page.dart
@@ -1,0 +1,440 @@
+import 'package:baby_track_app/features/baby/domain/models/baby.dart';
+import 'package:baby_track_app/features/baby/domain/models/baby_growth_record.dart';
+import 'package:baby_track_app/features/baby/infrastructure/baby_growth_record_repository_impl.dart';
+import 'package:baby_track_app/shared/widgets/app_bars/baby_gradient_app_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class BabyGrowthPage extends StatefulWidget {
+  const BabyGrowthPage({super.key, required this.baby});
+
+  final Baby baby;
+
+  @override
+  State<BabyGrowthPage> createState() => _BabyGrowthPageState();
+}
+
+class _BabyGrowthPageState extends State<BabyGrowthPage> {
+  final BabyGrowthRecordRepositoryImpl _repository = BabyGrowthRecordRepositoryImpl();
+
+  bool _isLoading = false;
+  List<BabyGrowthRecord> _records = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadRecords();
+  }
+
+  Future<void> _loadRecords() async {
+    if (widget.baby.id == null) {
+      setState(() {
+        _records = const [];
+        _isLoading = false;
+      });
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final records = await _repository.getRecordsForBaby(widget.baby.id!);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _records = records;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: const BabyGradientAppBar(
+        title: 'Crecimiento',
+        subtitle: 'Seguimiento de medidas y percentiles',
+        icon: Icons.monitor_weight_rounded,
+      ),
+      body: RefreshIndicator(
+        onRefresh: _loadRecords,
+        displacement: 32,
+        child: widget.baby.id == null
+            ? ListView(
+                physics: const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+                children: [
+                  _EmptyStateCard(
+                    icon: Icons.assignment_ind_rounded,
+                    title: 'Registra primero a tu bebé',
+                    message:
+                        'Guarda el perfil de ${widget.baby.name} para comenzar a documentar su crecimiento.',
+                  ),
+                ],
+              )
+            : _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _records.isEmpty
+                    ? ListView(
+                        physics:
+                            const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+                        children: const [
+                          _EmptyStateCard(
+                            icon: Icons.auto_graph_rounded,
+                            title: 'Aún no hay mediciones',
+                            message:
+                                'Registra las revisiones pediátricas para ver aquí la evolución de peso, talla y perímetro craneal.',
+                          ),
+                        ],
+                      )
+                    : ListView(
+                        physics:
+                            const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+                        children: _buildGroupedRecords(theme),
+                      ),
+      ),
+    );
+  }
+
+  List<Widget> _buildGroupedRecords(ThemeData theme) {
+    final formatter = DateFormat('MMMM yyyy', 'es');
+    final grouped = <String, List<BabyGrowthRecord>>{};
+    for (final record in _records) {
+      final key = formatter.format(record.recordedAt).toUpperCase();
+      grouped.putIfAbsent(key, () => []).add(record);
+    }
+
+    return grouped.entries
+        .map(
+          (entry) => Padding(
+            padding: const EdgeInsets.only(bottom: 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  entry.key,
+                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 12),
+                ...entry.value.map((record) => _GrowthRecordCard(record: record)).toList(),
+              ],
+            ),
+          ),
+        )
+        .toList(growable: false);
+  }
+}
+
+class _GrowthRecordCard extends StatelessWidget {
+  const _GrowthRecordCard({required this.record});
+
+  final BabyGrowthRecord record;
+
+  String _formatDate(DateTime date) {
+    final formatter = DateFormat('d MMM yyyy', 'es');
+    return formatter.format(date);
+  }
+
+  String _formatMeasurement(double? value, String unit) {
+    if (value == null) {
+      return 'Sin dato';
+    }
+    return '${value.toStringAsFixed(value % 1 == 0 ? 0 : 1)} $unit';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 20,
+            offset: const Offset(0, 14),
+          ),
+        ],
+        border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.6)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.calendar_today_rounded, color: colorScheme.primary),
+              const SizedBox(width: 12),
+              Text(
+                _formatDate(record.recordedAt),
+                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          _MeasurementBlock(
+            title: 'Perímetro craneal',
+            valueLabel: _formatMeasurement(record.headCircumferenceCm, 'cm'),
+            percentile: record.headCircumferencePercentile,
+            color: colorScheme.primary,
+          ),
+          const SizedBox(height: 16),
+          _MeasurementBlock(
+            title: 'Altura',
+            valueLabel: _formatMeasurement(record.heightCm, 'cm'),
+            percentile: record.heightPercentile,
+            color: colorScheme.secondary,
+          ),
+          const SizedBox(height: 16),
+          _MeasurementBlock(
+            title: 'Peso',
+            valueLabel: _formatMeasurement(record.weightKg, 'kg'),
+            percentile: record.weightPercentile,
+            color: colorScheme.tertiary,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MeasurementBlock extends StatelessWidget {
+  const _MeasurementBlock({
+    required this.title,
+    required this.valueLabel,
+    required this.percentile,
+    required this.color,
+  });
+
+  final String title;
+  final String valueLabel;
+  final double? percentile;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 6),
+        Row(
+          children: [
+            Icon(Icons.stacked_line_chart_rounded, color: color),
+            const SizedBox(width: 8),
+            Text(
+              valueLabel,
+              style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        if (percentile != null)
+          _PercentileBar(percentile: percentile!, color: color)
+        else
+          Text(
+            'Añade los percentiles para visualizar la curva de crecimiento.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.6),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _PercentileBar extends StatelessWidget {
+  const _PercentileBar({required this.percentile, required this.color});
+
+  final double percentile;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final clamped = percentile.clamp(0, 100).toDouble();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          height: 48,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final widthFactor = constraints.maxWidth == 0
+                  ? 0.0
+                  : (clamped / 100).clamp(0.0, 1.0);
+              final markerPosition = constraints.maxWidth * widthFactor;
+
+              return Stack(
+                children: [
+                  Container(
+                    height: 48,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(16),
+                      gradient: LinearGradient(
+                        colors: [color.withOpacity(0.2), color.withOpacity(0.05)],
+                      ),
+                      border: Border.all(color: color.withOpacity(0.35)),
+                    ),
+                  ),
+                  Positioned.fill(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(10),
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: FractionallySizedBox(
+                                  widthFactor: widthFactor,
+                                  child: Container(
+                                    decoration: BoxDecoration(
+                                      gradient: LinearGradient(
+                                        begin: Alignment.centerLeft,
+                                        end: Alignment.centerRight,
+                                        colors: [color, color.withOpacity(0.6)],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    left: markerPosition.clamp(12.0, constraints.maxWidth - 12),
+                    top: 8,
+                    child: _PercentileMarker(color: color),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Percentil ${clamped.toStringAsFixed(0)}',
+          style: textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+      ],
+    );
+  }
+}
+
+class _PercentileMarker extends StatelessWidget {
+  const _PercentileMarker({required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 4,
+          height: 20,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(2),
+            boxShadow: [
+              BoxShadow(
+                color: color.withOpacity(0.4),
+                blurRadius: 8,
+                offset: const Offset(0, 3),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 4),
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+            border: Border.all(color: Colors.white, width: 1.5),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyStateCard extends StatelessWidget {
+  const _EmptyStateCard({
+    required this.icon,
+    required this.title,
+    required this.message,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(28),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(28),
+        border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.6)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 44, color: colorScheme.primary),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.7),
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_menu_page.dart
@@ -2,10 +2,14 @@ import 'dart:io';
 
 import 'package:baby_track_app/features/baby/domain/models/baby.dart';
 import 'package:baby_track_app/features/baby/domain/models/baby_daily_log.dart';
+import 'package:baby_track_app/features/baby/domain/models/baby_medical_event.dart';
 import 'package:baby_track_app/features/baby/infrastructure/baby_daily_log_repository_impl.dart';
+import 'package:baby_track_app/features/baby/infrastructure/baby_medical_event_repository_impl.dart';
 import 'package:baby_track_app/features/baby/presentation/pages/baby_daily_log_page.dart';
+import 'package:baby_track_app/features/baby/presentation/pages/baby_growth_page.dart';
 import 'package:baby_track_app/features/baby/presentation/pages/baby_history_page.dart';
 import 'package:baby_track_app/features/baby/presentation/pages/baby_medical_calendar_page.dart';
+import 'package:baby_track_app/features/baby/presentation/pages/baby_statistics_page.dart';
 import 'package:baby_track_app/shared/widgets/app_bars/baby_gradient_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -21,10 +25,12 @@ class BabyMenuPage extends StatefulWidget {
 
 class _BabyMenuPageState extends State<BabyMenuPage> {
   final BabyDailyLogRepositoryImpl _dailyLogRepository = BabyDailyLogRepositoryImpl();
+  final BabyMedicalEventRepositoryImpl _medicalEventRepository = BabyMedicalEventRepositoryImpl();
 
   bool _isLoadingStats = false;
   List<BabyDailyLog> _todayLogs = const [];
   List<BabyDailyLog> _recentLogs = const [];
+  List<BabyMedicalEvent> _upcomingEvents = const [];
 
   @override
   void initState() {
@@ -41,6 +47,7 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
       setState(() {
         _todayLogs = const [];
         _recentLogs = const [];
+        _upcomingEvents = const [];
         _isLoadingStats = false;
       });
       return;
@@ -55,6 +62,10 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
       final today = DateTime(now.year, now.month, now.day);
       final todayLogs = await _dailyLogRepository.getLogsForBabyOnDate(widget.baby.id!, today);
       final recentLogs = await _dailyLogRepository.getRecentLogsForBaby(widget.baby.id!, limit: 60);
+      final upcomingEvents = await _medicalEventRepository.getUpcomingEventsForBaby(
+        widget.baby.id!,
+        within: const Duration(days: 30),
+      );
 
       if (!mounted) {
         return;
@@ -63,6 +74,7 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
       setState(() {
         _todayLogs = todayLogs;
         _recentLogs = recentLogs;
+        _upcomingEvents = upcomingEvents;
       });
     } finally {
       if (mounted) {
@@ -102,6 +114,68 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
         return colorScheme.secondary;
       default:
         return colorScheme.tertiary;
+    }
+  }
+
+  String _formatAppointmentDate(DateTime date) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final appointmentDay = DateTime(date.year, date.month, date.day);
+
+    if (_isSameDay(appointmentDay, today)) {
+      return 'Hoy · ${DateFormat('HH:mm').format(date)}';
+    }
+
+    if (_isSameDay(appointmentDay, today.add(const Duration(days: 1)))) {
+      return 'Mañana · ${DateFormat('HH:mm').format(date)}';
+    }
+
+    final difference = appointmentDay.difference(today).inDays;
+    if (difference > 1 && difference < 7) {
+      final weekday = DateFormat('EEEE', 'es').format(date);
+      return '${_capitalize(weekday)} · ${DateFormat('HH:mm').format(date)}';
+    }
+
+    return DateFormat('d MMM yyyy · HH:mm', 'es').format(date);
+  }
+
+  String _capitalize(String text) {
+    if (text.isEmpty) {
+      return text;
+    }
+    return text[0].toUpperCase() + text.substring(1);
+  }
+
+  String _eventTypeLabel(String type) {
+    switch (type) {
+      case 'vaccine':
+        return 'Vacuna';
+      case 'checkup':
+        return 'Chequeo pediátrico';
+      default:
+        return 'Otro cuidado';
+    }
+  }
+
+  Color _eventTypeColor(String type, ColorScheme colorScheme) {
+    switch (type) {
+      case 'vaccine':
+        return colorScheme.primary;
+      case 'checkup':
+        return colorScheme.secondary;
+      default:
+        return colorScheme.tertiary;
+    }
+  }
+
+  IconData _eventTypeIcon(String type) {
+    switch (type) {
+      case 'vaccine':
+        return Icons.vaccines_rounded;
+      case 'checkup':
+        return Icons.monitor_heart_rounded;
+      default:
+        return Icons.medical_services_rounded;
     }
   }
 
@@ -240,9 +314,23 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
                             ),
                           );
                         },
+                        onOpenStatistics: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => BabyStatisticsPage(baby: baby),
+                            ),
+                          );
+                        },
+                        onOpenGrowth: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => BabyGrowthPage(baby: baby),
+                            ),
+                          );
+                        },
                       ),
                       const SizedBox(height: 28),
-                      _buildStatsSection(colorScheme, textTheme),
+                      _buildStatsSection(context, colorScheme, textTheme),
                     ],
                   ),
                 ),
@@ -254,7 +342,7 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
     );
   }
 
-  Widget _buildStatsSection(ColorScheme colorScheme, TextTheme textTheme) {
+  Widget _buildStatsSection(BuildContext context, ColorScheme colorScheme, TextTheme textTheme) {
     if (widget.baby.id == null) {
       return Container(
         padding: const EdgeInsets.all(24),
@@ -305,6 +393,24 @@ class _BabyMenuPageState extends State<BabyMenuPage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        if (_upcomingEvents.isNotEmpty) ...[
+          _UpcomingAppointmentsCard(
+            events: _upcomingEvents,
+            colorScheme: colorScheme,
+            onViewCalendar: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => BabyMedicalCalendarPage(baby: widget.baby),
+                ),
+              );
+            },
+            eventTypeLabel: _eventTypeLabel,
+            eventTypeColor: (type) => _eventTypeColor(type, colorScheme),
+            formatDateLabel: _formatAppointmentDate,
+            eventTypeIcon: _eventTypeIcon,
+          ),
+          const SizedBox(height: 16),
+        ],
         _BabyStatsCard(
           title: 'Última actividad',
           children: [
@@ -456,11 +562,15 @@ class _BabyQuickActions extends StatefulWidget {
     required this.onCreateLog,
     required this.onViewHistory,
     required this.onOpenMedicalCalendar,
+    required this.onOpenStatistics,
+    required this.onOpenGrowth,
   });
 
   final VoidCallback onCreateLog;
   final VoidCallback onViewHistory;
   final VoidCallback onOpenMedicalCalendar;
+  final VoidCallback onOpenStatistics;
+  final VoidCallback onOpenGrowth;
 
   @override
   State<_BabyQuickActions> createState() => _BabyQuickActionsState();
@@ -503,6 +613,18 @@ class _BabyQuickActionsState extends State<_BabyQuickActions> {
         label: 'Agenda médica',
         color: colorScheme.tertiary,
         onTap: widget.onOpenMedicalCalendar,
+      ),
+      _QuickActionData(
+        icon: Icons.query_stats_rounded,
+        label: 'Estadísticas',
+        color: colorScheme.primaryContainer,
+        onTap: widget.onOpenStatistics,
+      ),
+      _QuickActionData(
+        icon: Icons.monitor_weight_rounded,
+        label: 'Crecimiento',
+        color: colorScheme.secondaryContainer,
+        onTap: widget.onOpenGrowth,
       ),
     ];
 
@@ -780,6 +902,177 @@ class _BabyStatTile extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _UpcomingAppointmentsCard extends StatelessWidget {
+  const _UpcomingAppointmentsCard({
+    required this.events,
+    required this.colorScheme,
+    required this.onViewCalendar,
+    required this.eventTypeLabel,
+    required this.eventTypeColor,
+    required this.formatDateLabel,
+    required this.eventTypeIcon,
+  });
+
+  final List<BabyMedicalEvent> events;
+  final ColorScheme colorScheme;
+  final VoidCallback onViewCalendar;
+  final String Function(String type) eventTypeLabel;
+  final Color Function(String type) eventTypeColor;
+  final String Function(DateTime date) formatDateLabel;
+  final IconData Function(String type) eventTypeIcon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final previewEvents = events.take(3).toList(growable: false);
+    final remaining = events.length - previewEvents.length;
+
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 20,
+            offset: const Offset(0, 14),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: colorScheme.primary.withOpacity(0.12),
+                ),
+                child: Icon(Icons.calendar_month_rounded, color: colorScheme.primary),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'Próximas citas',
+                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                ),
+              ),
+              TextButton.icon(
+                onPressed: onViewCalendar,
+                icon: const Icon(Icons.open_in_new_rounded, size: 18),
+                label: const Text('Ver agenda'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          for (var index = 0; index < previewEvents.length; index++)
+            Padding(
+              padding: EdgeInsets.only(bottom: index == previewEvents.length - 1 ? 0 : 14),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 42,
+                    height: 42,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: eventTypeColor(previewEvents[index].eventType).withOpacity(0.15),
+                    ),
+                    child: Icon(
+                      eventTypeIcon(previewEvents[index].eventType),
+                      color: eventTypeColor(previewEvents[index].eventType),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          previewEvents[index].title,
+                          style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w700),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          formatDateLabel(previewEvents[index].scheduledAt),
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.onSurface.withOpacity(0.75),
+                          ),
+                        ),
+                        const SizedBox(height: 6),
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          children: [
+                            _EventTag(
+                              label: eventTypeLabel(previewEvents[index].eventType),
+                              color: eventTypeColor(previewEvents[index].eventType),
+                            ),
+                            if ((previewEvents[index].location ?? '').isNotEmpty)
+                              _EventTag(
+                                label: previewEvents[index].location!,
+                                color: colorScheme.outline,
+                                isOutlined: true,
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          if (remaining > 0)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                'Y $remaining ${remaining == 1 ? 'cita adicional' : 'citas adicionales'} registradas.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurface.withOpacity(0.6),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventTag extends StatelessWidget {
+  const _EventTag({
+    required this.label,
+    required this.color,
+    this.isOutlined = false,
+  });
+
+  final String label;
+  final Color color;
+  final bool isOutlined;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: isOutlined ? Colors.transparent : color.withOpacity(0.14),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: isOutlined ? color.withOpacity(0.6) : Colors.transparent),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: isOutlined ? color : color.withOpacity(0.9),
+            ),
+      ),
     );
   }
 }

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_statistics_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_statistics_page.dart
@@ -1,0 +1,510 @@
+import 'package:baby_track_app/features/baby/domain/models/baby.dart';
+import 'package:baby_track_app/features/baby/domain/models/baby_daily_log.dart';
+import 'package:baby_track_app/features/baby/infrastructure/baby_daily_log_repository_impl.dart';
+import 'package:baby_track_app/shared/widgets/app_bars/baby_gradient_app_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class BabyStatisticsPage extends StatefulWidget {
+  const BabyStatisticsPage({super.key, required this.baby});
+
+  final Baby baby;
+
+  @override
+  State<BabyStatisticsPage> createState() => _BabyStatisticsPageState();
+}
+
+class _BabyStatisticsPageState extends State<BabyStatisticsPage> {
+  final BabyDailyLogRepositoryImpl _repository = BabyDailyLogRepositoryImpl();
+
+  bool _isLoading = false;
+  List<BabyDailyLog> _recentLogs = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadStats();
+  }
+
+  Future<void> _loadStats() async {
+    if (widget.baby.id == null) {
+      setState(() {
+        _recentLogs = const [];
+        _isLoading = false;
+      });
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final logs = await _repository.getRecentLogsForBaby(widget.baby.id!, limit: 180);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _recentLogs = logs;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: const BabyGradientAppBar(
+        title: 'Estadísticas',
+        subtitle: 'Tendencias de cuidados diarios',
+        icon: Icons.query_stats_rounded,
+      ),
+      body: RefreshIndicator(
+        onRefresh: _loadStats,
+        displacement: 32,
+        child: widget.baby.id == null
+            ? ListView(
+                physics: const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+                children: [
+                  _StatsEmptyState(
+                    icon: Icons.assignment_ind_outlined,
+                    message:
+                        'Guarda el perfil de ${widget.baby.name} para poder analizar sus rutinas y hábitos.',
+                  ),
+                ],
+              )
+            : _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _recentLogs.isEmpty
+                    ? ListView(
+                        physics:
+                            const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+                        children: const [
+                          _StatsEmptyState(
+                            icon: Icons.insights_outlined,
+                            message:
+                                'Registra las tomas, pañales y demás actividades para visualizar estadísticas aquí.',
+                          ),
+                        ],
+                      )
+                    : ListView(
+                        physics:
+                            const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+                        children: _buildStatsCards(context),
+                      ),
+      ),
+    );
+  }
+
+  List<Widget> _buildStatsCards(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    final groupedByDay = <DateTime, List<BabyDailyLog>>{};
+    for (final log in _recentLogs) {
+      final day = DateTime(log.loggedAt.year, log.loggedAt.month, log.loggedAt.day);
+      groupedByDay.putIfAbsent(day, () => []).add(log);
+    }
+
+    final days = groupedByDay.keys.toList()
+      ..sort((a, b) => b.compareTo(a));
+
+    final summaries = days.map((day) {
+      final logs = groupedByDay[day] ?? [];
+      final intakeLogs = logs.where((log) => (log.intakeMl ?? 0) > 0).toList();
+      final feedCount = intakeLogs.length;
+      final totalIntake = intakeLogs.fold<int>(0, (sum, log) => sum + (log.intakeMl ?? 0));
+      final poopCount = logs.where((log) => log.didPoop).length;
+      final showerCount = logs.where((log) => log.showered).length;
+      final vomitCount = logs.where((log) => log.vomited).length;
+      final notesCount = logs.where((log) => (log.notes ?? '').isNotEmpty).length;
+
+      return _DailySummary(
+        day: day,
+        feedCount: feedCount,
+        totalIntake: totalIntake,
+        poopCount: poopCount,
+        showerCount: showerCount,
+        vomitCount: vomitCount,
+        notesCount: notesCount,
+      );
+    }).toList();
+
+    final lastSeven = summaries.take(7).toList();
+    final weeklyAverageFeed = lastSeven.isEmpty
+        ? 0
+        : lastSeven.map((summary) => summary.feedCount).reduce((a, b) => a + b) /
+            lastSeven.length;
+
+    final weeklyAverageIntake = lastSeven.isEmpty
+        ? 0
+        : lastSeven.map((summary) => summary.totalIntake).reduce((a, b) => a + b) /
+            lastSeven.length;
+
+    final cards = <Widget>[
+      _StatsOverviewCard(
+        averageFeeds: weeklyAverageFeed,
+        averageIntake: weeklyAverageIntake,
+        trendLabel: _buildTrendLabel(weeklyAverageFeed),
+      ),
+      const SizedBox(height: 24),
+      Text(
+        'Resumen diario (últimos 30 días)',
+        style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+      ),
+      const SizedBox(height: 12),
+    ];
+
+    cards.addAll(
+      summaries.take(30).map((summary) {
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 16),
+          child: _DailyStatsCard(summary: summary, colorScheme: colorScheme),
+        );
+      }),
+    );
+
+    return cards;
+  }
+
+  String _buildTrendLabel(double averageFeeds) {
+    if (averageFeeds == 0) {
+      return 'Aún sin datos suficientes para mostrar tendencias.';
+    }
+    if (averageFeeds < 5) {
+      return 'Rutina tranquila. La media es de ${averageFeeds.toStringAsFixed(1)} tomas por día.';
+    }
+    if (averageFeeds < 8) {
+      return 'Excelente ritmo. ${averageFeeds.toStringAsFixed(1)} tomas diarias en promedio.';
+    }
+    return 'Alta demanda. ${averageFeeds.toStringAsFixed(1)} tomas al día en la última semana.';
+  }
+}
+
+class _StatsOverviewCard extends StatelessWidget {
+  const _StatsOverviewCard({
+    required this.averageFeeds,
+    required this.averageIntake,
+    required this.trendLabel,
+  });
+
+  final double averageFeeds;
+  final double averageIntake;
+  final String trendLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(28),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [colorScheme.primary.withOpacity(0.12), Colors.white],
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.08),
+            blurRadius: 26,
+            offset: const Offset(0, 18),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.leaderboard_rounded, color: colorScheme.primary),
+              const SizedBox(width: 12),
+              Text(
+                'Promedios de la última semana',
+                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 24,
+            runSpacing: 16,
+            children: [
+              _OverviewMetric(
+                label: 'Tomas diarias',
+                value: averageFeeds == 0 ? '—' : averageFeeds.toStringAsFixed(1),
+                icon: Icons.local_drink_rounded,
+                color: colorScheme.primary,
+              ),
+              _OverviewMetric(
+                label: 'Cantidad promedio',
+                value: averageIntake == 0 ? '—' : '${averageIntake.toStringAsFixed(0)} ml',
+                icon: Icons.scale_rounded,
+                color: colorScheme.secondary,
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          Text(
+            trendLabel,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.75),
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OverviewMetric extends StatelessWidget {
+  const _OverviewMetric({
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        color: color.withOpacity(0.08),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: color),
+          const SizedBox(width: 12),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                value,
+                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+              ),
+              Text(
+                label,
+                style: theme.textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w500),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DailyStatsCard extends StatelessWidget {
+  const _DailyStatsCard({required this.summary, required this.colorScheme});
+
+  final _DailySummary summary;
+  final ColorScheme colorScheme;
+
+  String _formatDate(DateTime day) {
+    final formatter = DateFormat('EEE d MMM', 'es');
+    return formatter.format(day);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 20,
+            offset: const Offset(0, 14),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.today_rounded, color: colorScheme.primary),
+              const SizedBox(width: 12),
+              Text(
+                _formatDate(summary.day).toUpperCase(),
+                style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 20,
+            runSpacing: 12,
+            children: [
+              _StatChip(
+                icon: Icons.local_cafe_rounded,
+                color: colorScheme.primary,
+                label: summary.feedCount == 1
+                    ? '1 toma'
+                    : '${summary.feedCount} tomas',
+              ),
+              _StatChip(
+                icon: Icons.local_drink_rounded,
+                color: colorScheme.secondary,
+                label: summary.totalIntake == 0
+                    ? 'Sin registro de ml'
+                    : '${summary.totalIntake} ml',
+              ),
+              _StatChip(
+                icon: Icons.baby_changing_station_rounded,
+                color: colorScheme.tertiary,
+                label: summary.poopCount == 1
+                    ? '1 pañal'
+                    : '${summary.poopCount} pañales',
+              ),
+              _StatChip(
+                icon: Icons.bathtub_rounded,
+                color: colorScheme.primaryContainer,
+                label: summary.showerCount == 1
+                    ? '1 baño'
+                    : '${summary.showerCount} baños',
+              ),
+              _StatChip(
+                icon: Icons.sick_rounded,
+                color: colorScheme.error,
+                label: summary.vomitCount == 0
+                    ? 'Sin vómitos'
+                    : '${summary.vomitCount} ${summary.vomitCount == 1 ? 'vómito' : 'vómitos'}',
+              ),
+              if (summary.notesCount > 0)
+                _StatChip(
+                  icon: Icons.sticky_note_2_rounded,
+                  color: colorScheme.outline,
+                  label: summary.notesCount == 1
+                      ? '1 nota registrada'
+                      : '${summary.notesCount} notas registradas',
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatChip extends StatelessWidget {
+  const _StatChip({
+    required this.icon,
+    required this.color,
+    required this.label,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: color, size: 18),
+          const SizedBox(width: 8),
+          Text(label),
+        ],
+      ),
+    );
+  }
+}
+
+class _DailySummary {
+  const _DailySummary({
+    required this.day,
+    required this.feedCount,
+    required this.totalIntake,
+    required this.poopCount,
+    required this.showerCount,
+    required this.vomitCount,
+    required this.notesCount,
+  });
+
+  final DateTime day;
+  final int feedCount;
+  final int totalIntake;
+  final int poopCount;
+  final int showerCount;
+  final int vomitCount;
+  final int notesCount;
+}
+
+class _StatsEmptyState extends StatelessWidget {
+  const _StatsEmptyState({required this.icon, required this.message});
+
+  final IconData icon;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(28),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(28),
+        border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.6)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 42, color: colorScheme.primary),
+          const SizedBox(height: 16),
+          Text(
+            'Sin estadísticas por ahora',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.7),
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/baby_track_app/lib/shared/data/database/database_helper.dart
+++ b/baby_track_app/lib/shared/data/database/database_helper.dart
@@ -4,7 +4,7 @@ import 'package:sqflite/sqflite.dart';
 /// Sistema de migraciones siguiendo AGENTS.md
 class DatabaseHelper {
   static const String _databaseName = 'baby_track.db';
-  static const int _databaseVersion = 5; // Incrementado para agenda médica
+  static const int _databaseVersion = 6; // Incrementado para registros de crecimiento
 
   static final DatabaseHelper _instance = DatabaseHelper._internal();
   static Database? _database;
@@ -35,6 +35,7 @@ class DatabaseHelper {
     await _createBabiesTableV2(db);
     await _createBabyDailyLogsTable(db);
     await _createBabyMedicalEventsTable(db);
+    await _createBabyGrowthRecordsTable(db);
     await _createIndices(db);
   }
 
@@ -62,6 +63,11 @@ class DatabaseHelper {
       await _upgradeToV5(db);
     }
 
+    // Migración de v5 a v6: crear tabla baby_growth_records
+    if (oldVersion < 6) {
+      await _upgradeToV6(db);
+    }
+
     // Futuras migraciones
     // if (oldVersion < 3) {
     //   await _upgradeToV3(db);
@@ -76,6 +82,8 @@ class DatabaseHelper {
         'CREATE INDEX IF NOT EXISTS idx_baby_daily_logs_baby_day ON baby_daily_logs(baby_id, log_day)');
     await db.execute(
         'CREATE INDEX IF NOT EXISTS idx_baby_medical_events_baby_date ON baby_medical_events(baby_id, scheduled_at)');
+    await db.execute(
+        'CREATE INDEX IF NOT EXISTS idx_baby_growth_records_baby_date ON baby_growth_records(baby_id, recorded_at)');
   }
 
   /// Tabla v2 (con gender)
@@ -125,6 +133,25 @@ class DatabaseHelper {
         reminder_enabled INTEGER NOT NULL DEFAULT 1,
         reminder_minutes_before INTEGER NOT NULL DEFAULT 1440,
         reminder_sent_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER,
+        FOREIGN KEY (baby_id) REFERENCES babies(id) ON DELETE CASCADE
+      )
+    ''');
+  }
+
+  Future<void> _createBabyGrowthRecordsTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE baby_growth_records (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        baby_id INTEGER NOT NULL,
+        recorded_at INTEGER NOT NULL,
+        height_cm REAL,
+        weight_kg REAL,
+        head_circumference_cm REAL,
+        height_percentile REAL,
+        weight_percentile REAL,
+        head_circumference_percentile REAL,
         created_at INTEGER NOT NULL,
         updated_at INTEGER,
         FOREIGN KEY (baby_id) REFERENCES babies(id) ON DELETE CASCADE
@@ -189,6 +216,19 @@ class DatabaseHelper {
       print('Successfully created baby_medical_events table');
     } catch (e) {
       print('Error during v4 to v5 migration: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> _upgradeToV6(Database db) async {
+    try {
+      await _createBabyGrowthRecordsTable(db);
+      await db.execute(
+        'CREATE INDEX IF NOT EXISTS idx_baby_growth_records_baby_date ON baby_growth_records(baby_id, recorded_at)',
+      );
+      print('Successfully created baby_growth_records table');
+    } catch (e) {
+      print('Error during v5 to v6 migration: $e');
       rethrow;
     }
   }


### PR DESCRIPTION
## Summary
- add persistence primitives for baby growth measurements and database migration support
- implement the growth screen with grouped measurements, percentile visuals, and empty states
- surface a detailed statistics page and expose it from the baby menu alongside upcoming appointments

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68deb2ae74d883328931bc245386921d