### PR TITLE
fix: ensure weekly averages use double

### DIFF
--- a/baby_track_app/lib/features/baby/presentation/pages/baby_statistics_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_statistics_page.dart
@@ -142,13 +142,13 @@ class _BabyStatisticsPageState extends State<BabyStatisticsPage> {
     }).toList();
 
     final lastSeven = summaries.take(7).toList();
-    final weeklyAverageFeed = lastSeven.isEmpty
-        ? 0
+    final double weeklyAverageFeed = lastSeven.isEmpty
+        ? 0.0
         : lastSeven.map((summary) => summary.feedCount).reduce((a, b) => a + b) /
             lastSeven.length;
 
-    final weeklyAverageIntake = lastSeven.isEmpty
-        ? 0
+    final double weeklyAverageIntake = lastSeven.isEmpty
+        ? 0.0
         : lastSeven.map((summary) => summary.totalIntake).reduce((a, b) => a + b) /
             lastSeven.length;
 


### PR DESCRIPTION
## Summary
- ensure weekly average feed and intake values are typed as doubles before rendering the statistics overview card

**Agente responsable:** Agente Estado & Dominio

## Testing
- flutter analyze *(fails: Flutter SDK no está disponible en el entorno de ejecución)*

------
https://chatgpt.com/codex/tasks/task_b_68deb5e8044083328394c02834214326