### PR TITLE
feat: add WHO percentile charts to growth records

### DIFF
--- a/baby_track_app/lib/features/baby/domain/growth/who_growth_standards.dart
+++ b/baby_track_app/lib/features/baby/domain/growth/who_growth_standards.dart
@@ -1,0 +1,301 @@
+import 'dart:math' as math;
+
+enum BabyGender { male, female }
+
+enum GrowthMetric { weight, height, headCircumference }
+
+class WhoGrowthEntry {
+  const WhoGrowthEntry({
+    required this.ageMonths,
+    required this.p3,
+    required this.p15,
+    required this.p50,
+    required this.p85,
+    required this.p97,
+  });
+
+  final double ageMonths;
+  final double p3;
+  final double p15;
+  final double p50;
+  final double p85;
+  final double p97;
+
+  List<double> get percentileValues => [p3, p15, p50, p85, p97];
+}
+
+class WhoGrowthStandards {
+  const WhoGrowthStandards._();
+
+  static List<WhoGrowthEntry> entriesFor({
+    required BabyGender gender,
+    required GrowthMetric metric,
+  }) {
+    switch (metric) {
+      case GrowthMetric.weight:
+        return gender == BabyGender.male
+            ? _weightBoys0To24Months
+            : _weightGirls0To24Months;
+      case GrowthMetric.height:
+        return gender == BabyGender.male
+            ? _lengthBoys0To24Months
+            : _lengthGirls0To24Months;
+      case GrowthMetric.headCircumference:
+        return gender == BabyGender.male
+            ? _headBoys0To24Months
+            : _headGirls0To24Months;
+    }
+  }
+
+  static double? percentileForMeasurement({
+    required double? measurement,
+    required double ageMonths,
+    required BabyGender gender,
+    required GrowthMetric metric,
+  }) {
+    if (measurement == null) {
+      return null;
+    }
+    final data = entriesFor(gender: gender, metric: metric);
+    if (data.isEmpty) {
+      return null;
+    }
+    final clampedAge = ageMonths.clamp(data.first.ageMonths, data.last.ageMonths);
+    final _AgeBracket bracket = _resolveAgeBracket(data, clampedAge);
+    final factor = bracket.upper.ageMonths == bracket.lower.ageMonths
+        ? 0.0
+        : (clampedAge - bracket.lower.ageMonths) /
+            (bracket.upper.ageMonths - bracket.lower.ageMonths);
+
+    final percentiles = [3.0, 15.0, 50.0, 85.0, 97.0];
+    final values = <double>[];
+    for (final getter in _valueGetters) {
+      final lower = getter(bracket.lower);
+      final upper = getter(bracket.upper);
+      final interpolated = lower + (upper - lower) * factor;
+      values.add(interpolated);
+    }
+
+    if (measurement <= values.first) {
+      final slope = (values[1] - values.first) / (percentiles[1] - percentiles.first);
+      final delta = (measurement - values.first) / slope;
+      return math.max(0, percentiles.first + delta);
+    }
+
+    for (var i = 0; i < values.length - 1; i++) {
+      final current = values[i];
+      final next = values[i + 1];
+      if (measurement <= next) {
+        final slope = (next - current) / (percentiles[i + 1] - percentiles[i]);
+        final delta = (measurement - current) / slope;
+        return percentiles[i] + delta;
+      }
+    }
+
+    final slope =
+        (values.last - values[values.length - 2]) /
+        (percentiles.last - percentiles[percentiles.length - 2]);
+    final delta = (measurement - values.last) / slope;
+    return math.min(100, percentiles.last + delta);
+  }
+
+  static _AgeBracket _resolveAgeBracket(List<WhoGrowthEntry> data, double ageMonths) {
+    WhoGrowthEntry lower = data.first;
+    WhoGrowthEntry upper = data.last;
+
+    for (final entry in data) {
+      if (entry.ageMonths <= ageMonths) {
+        lower = entry;
+      }
+      if (entry.ageMonths >= ageMonths) {
+        upper = entry;
+        break;
+      }
+    }
+
+    return _AgeBracket(lower: lower, upper: upper);
+  }
+
+  static final List<double Function(WhoGrowthEntry)> _valueGetters = [
+    (entry) => entry.p3,
+    (entry) => entry.p15,
+    (entry) => entry.p50,
+    (entry) => entry.p85,
+    (entry) => entry.p97,
+  ];
+
+  static const List<WhoGrowthEntry> _lengthBoys0To24Months = [
+    WhoGrowthEntry(ageMonths: 0, p3: 46.1, p15: 48.0, p50: 49.9, p85: 51.8, p97: 53.4),
+    WhoGrowthEntry(ageMonths: 1, p3: 50.8, p15: 52.7, p50: 54.7, p85: 56.7, p97: 58.4),
+    WhoGrowthEntry(ageMonths: 2, p3: 54.4, p15: 56.4, p50: 58.4, p85: 60.4, p97: 62.2),
+    WhoGrowthEntry(ageMonths: 3, p3: 57.3, p15: 59.4, p50: 61.4, p85: 63.5, p97: 65.3),
+    WhoGrowthEntry(ageMonths: 4, p3: 59.7, p15: 61.8, p50: 63.9, p85: 66.1, p97: 68.0),
+    WhoGrowthEntry(ageMonths: 5, p3: 61.7, p15: 63.8, p50: 65.9, p85: 68.1, p97: 70.0),
+    WhoGrowthEntry(ageMonths: 6, p3: 63.3, p15: 65.4, p50: 67.6, p85: 69.8, p97: 71.6),
+    WhoGrowthEntry(ageMonths: 7, p3: 64.7, p15: 66.9, p50: 69.2, p85: 71.3, p97: 73.1),
+    WhoGrowthEntry(ageMonths: 8, p3: 66.0, p15: 68.2, p50: 70.6, p85: 72.7, p97: 74.5),
+    WhoGrowthEntry(ageMonths: 9, p3: 67.2, p15: 69.5, p50: 72.0, p85: 74.1, p97: 75.9),
+    WhoGrowthEntry(ageMonths: 10, p3: 68.4, p15: 70.7, p50: 73.3, p85: 75.3, p97: 77.2),
+    WhoGrowthEntry(ageMonths: 11, p3: 69.6, p15: 71.9, p50: 74.5, p85: 76.6, p97: 78.5),
+    WhoGrowthEntry(ageMonths: 12, p3: 70.6, p15: 73.0, p50: 75.7, p85: 77.8, p97: 79.7),
+    WhoGrowthEntry(ageMonths: 13, p3: 71.6, p15: 74.1, p50: 76.9, p85: 79.1, p97: 81.0),
+    WhoGrowthEntry(ageMonths: 14, p3: 72.6, p15: 75.1, p50: 78.0, p85: 80.2, p97: 82.1),
+    WhoGrowthEntry(ageMonths: 15, p3: 73.5, p15: 76.0, p50: 79.1, p85: 81.4, p97: 83.3),
+    WhoGrowthEntry(ageMonths: 16, p3: 74.4, p15: 77.0, p50: 80.2, p85: 82.5, p97: 84.4),
+    WhoGrowthEntry(ageMonths: 17, p3: 75.3, p15: 77.9, p50: 81.2, p85: 83.6, p97: 85.5),
+    WhoGrowthEntry(ageMonths: 18, p3: 76.1, p15: 78.8, p50: 82.3, p85: 84.7, p97: 86.6),
+    WhoGrowthEntry(ageMonths: 19, p3: 76.9, p15: 79.6, p50: 83.2, p85: 85.8, p97: 87.7),
+    WhoGrowthEntry(ageMonths: 20, p3: 77.7, p15: 80.5, p50: 84.2, p85: 86.8, p97: 88.7),
+    WhoGrowthEntry(ageMonths: 21, p3: 78.5, p15: 81.3, p50: 85.1, p85: 87.8, p97: 89.8),
+    WhoGrowthEntry(ageMonths: 22, p3: 79.2, p15: 82.0, p50: 86.0, p85: 88.8, p97: 90.8),
+    WhoGrowthEntry(ageMonths: 23, p3: 80.0, p15: 82.8, p50: 86.9, p85: 89.8, p97: 91.9),
+    WhoGrowthEntry(ageMonths: 24, p3: 80.7, p15: 83.6, p50: 87.8, p85: 90.7, p97: 92.9),
+  ];
+
+  static const List<WhoGrowthEntry> _lengthGirls0To24Months = [
+    WhoGrowthEntry(ageMonths: 0, p3: 45.4, p15: 47.3, p50: 49.1, p85: 51.0, p97: 52.7),
+    WhoGrowthEntry(ageMonths: 1, p3: 49.8, p15: 51.7, p50: 53.7, p85: 55.6, p97: 57.3),
+    WhoGrowthEntry(ageMonths: 2, p3: 53.0, p15: 55.0, p50: 57.1, p85: 59.1, p97: 60.9),
+    WhoGrowthEntry(ageMonths: 3, p3: 55.6, p15: 57.7, p50: 59.8, p85: 61.9, p97: 63.8),
+    WhoGrowthEntry(ageMonths: 4, p3: 57.8, p15: 59.9, p50: 62.0, p85: 64.2, p97: 66.1),
+    WhoGrowthEntry(ageMonths: 5, p3: 59.6, p15: 61.8, p50: 64.0, p85: 66.2, p97: 68.1),
+    WhoGrowthEntry(ageMonths: 6, p3: 61.2, p15: 63.5, p50: 65.7, p85: 67.9, p97: 69.8),
+    WhoGrowthEntry(ageMonths: 7, p3: 62.7, p15: 65.0, p50: 67.3, p85: 69.5, p97: 71.4),
+    WhoGrowthEntry(ageMonths: 8, p3: 64.0, p15: 66.4, p50: 68.7, p85: 71.0, p97: 72.9),
+    WhoGrowthEntry(ageMonths: 9, p3: 65.3, p15: 67.7, p50: 70.1, p85: 72.4, p97: 74.3),
+    WhoGrowthEntry(ageMonths: 10, p3: 66.5, p15: 69.0, p50: 71.5, p85: 73.8, p97: 75.8),
+    WhoGrowthEntry(ageMonths: 11, p3: 67.7, p15: 70.3, p50: 72.8, p85: 75.2, p97: 77.2),
+    WhoGrowthEntry(ageMonths: 12, p3: 68.9, p15: 71.5, p50: 74.0, p85: 76.5, p97: 78.5),
+    WhoGrowthEntry(ageMonths: 13, p3: 70.0, p15: 72.7, p50: 75.3, p85: 77.8, p97: 79.9),
+    WhoGrowthEntry(ageMonths: 14, p3: 71.0, p15: 73.8, p50: 76.5, p85: 79.1, p97: 81.2),
+    WhoGrowthEntry(ageMonths: 15, p3: 72.0, p15: 74.9, p50: 77.7, p85: 80.4, p97: 82.5),
+    WhoGrowthEntry(ageMonths: 16, p3: 73.0, p15: 76.0, p50: 78.9, p85: 81.7, p97: 83.8),
+    WhoGrowthEntry(ageMonths: 17, p3: 74.0, p15: 77.0, p50: 80.1, p85: 82.9, p97: 85.1),
+    WhoGrowthEntry(ageMonths: 18, p3: 74.9, p15: 78.0, p50: 81.2, p85: 84.1, p97: 86.3),
+    WhoGrowthEntry(ageMonths: 19, p3: 75.8, p15: 79.0, p50: 82.3, p85: 85.3, p97: 87.5),
+    WhoGrowthEntry(ageMonths: 20, p3: 76.7, p15: 80.0, p50: 83.4, p85: 86.5, p97: 88.7),
+    WhoGrowthEntry(ageMonths: 21, p3: 77.5, p15: 80.9, p50: 84.5, p85: 87.7, p97: 89.9),
+    WhoGrowthEntry(ageMonths: 22, p3: 78.4, p15: 81.9, p50: 85.5, p85: 88.9, p97: 91.1),
+    WhoGrowthEntry(ageMonths: 23, p3: 79.2, p15: 82.8, p50: 86.6, p85: 90.0, p97: 92.2),
+    WhoGrowthEntry(ageMonths: 24, p3: 80.0, p15: 83.7, p50: 87.6, p85: 91.1, p97: 93.4),
+  ];
+
+  static const List<WhoGrowthEntry> _weightBoys0To24Months = [
+    WhoGrowthEntry(ageMonths: 0, p3: 2.5, p15: 2.9, p50: 3.3, p85: 3.9, p97: 4.4),
+    WhoGrowthEntry(ageMonths: 1, p3: 3.4, p15: 3.9, p50: 4.5, p85: 5.2, p97: 5.8),
+    WhoGrowthEntry(ageMonths: 2, p3: 4.4, p15: 5.0, p50: 5.6, p85: 6.4, p97: 7.0),
+    WhoGrowthEntry(ageMonths: 3, p3: 5.1, p15: 5.8, p50: 6.4, p85: 7.2, p97: 7.9),
+    WhoGrowthEntry(ageMonths: 4, p3: 5.6, p15: 6.4, p50: 7.0, p85: 7.9, p97: 8.6),
+    WhoGrowthEntry(ageMonths: 5, p3: 6.0, p15: 6.9, p50: 7.5, p85: 8.4, p97: 9.1),
+    WhoGrowthEntry(ageMonths: 6, p3: 6.4, p15: 7.3, p50: 7.9, p85: 8.9, p97: 9.6),
+    WhoGrowthEntry(ageMonths: 7, p3: 6.7, p15: 7.6, p50: 8.3, p85: 9.3, p97: 10.0),
+    WhoGrowthEntry(ageMonths: 8, p3: 7.0, p15: 7.9, p50: 8.6, p85: 9.6, p97: 10.4),
+    WhoGrowthEntry(ageMonths: 9, p3: 7.2, p15: 8.2, p50: 8.9, p85: 10.0, p97: 10.7),
+    WhoGrowthEntry(ageMonths: 10, p3: 7.5, p15: 8.4, p50: 9.2, p85: 10.3, p97: 11.0),
+    WhoGrowthEntry(ageMonths: 11, p3: 7.7, p15: 8.7, p50: 9.4, p85: 10.5, p97: 11.3),
+    WhoGrowthEntry(ageMonths: 12, p3: 7.9, p15: 8.9, p50: 9.6, p85: 10.8, p97: 11.5),
+    WhoGrowthEntry(ageMonths: 13, p3: 8.1, p15: 9.1, p50: 9.9, p85: 11.0, p97: 11.8),
+    WhoGrowthEntry(ageMonths: 14, p3: 8.3, p15: 9.3, p50: 10.1, p85: 11.3, p97: 12.1),
+    WhoGrowthEntry(ageMonths: 15, p3: 8.5, p15: 9.5, p50: 10.3, p85: 11.5, p97: 12.3),
+    WhoGrowthEntry(ageMonths: 16, p3: 8.7, p15: 9.7, p50: 10.5, p85: 11.8, p97: 12.6),
+    WhoGrowthEntry(ageMonths: 17, p3: 8.9, p15: 9.9, p50: 10.7, p85: 12.0, p97: 12.8),
+    WhoGrowthEntry(ageMonths: 18, p3: 9.1, p15: 10.1, p50: 10.9, p85: 12.2, p97: 13.1),
+    WhoGrowthEntry(ageMonths: 19, p3: 9.2, p15: 10.3, p50: 11.1, p85: 12.5, p97: 13.3),
+    WhoGrowthEntry(ageMonths: 20, p3: 9.4, p15: 10.5, p50: 11.3, p85: 12.7, p97: 13.6),
+    WhoGrowthEntry(ageMonths: 21, p3: 9.6, p15: 10.7, p50: 11.5, p85: 12.9, p97: 13.8),
+    WhoGrowthEntry(ageMonths: 22, p3: 9.8, p15: 10.9, p50: 11.7, p85: 13.2, p97: 14.1),
+    WhoGrowthEntry(ageMonths: 23, p3: 10.0, p15: 11.1, p50: 11.9, p85: 13.4, p97: 14.3),
+    WhoGrowthEntry(ageMonths: 24, p3: 10.2, p15: 11.3, p50: 12.1, p85: 13.7, p97: 14.6),
+  ];
+
+  static const List<WhoGrowthEntry> _weightGirls0To24Months = [
+    WhoGrowthEntry(ageMonths: 0, p3: 2.4, p15: 2.8, p50: 3.2, p85: 3.7, p97: 4.2),
+    WhoGrowthEntry(ageMonths: 1, p3: 3.2, p15: 3.6, p50: 4.2, p85: 4.8, p97: 5.3),
+    WhoGrowthEntry(ageMonths: 2, p3: 4.0, p15: 4.5, p50: 5.1, p85: 5.8, p97: 6.4),
+    WhoGrowthEntry(ageMonths: 3, p3: 4.6, p15: 5.1, p50: 5.7, p85: 6.5, p97: 7.1),
+    WhoGrowthEntry(ageMonths: 4, p3: 5.1, p15: 5.6, p50: 6.2, p85: 7.0, p97: 7.6),
+    WhoGrowthEntry(ageMonths: 5, p3: 5.4, p15: 6.0, p50: 6.6, p85: 7.5, p97: 8.1),
+    WhoGrowthEntry(ageMonths: 6, p3: 5.7, p15: 6.3, p50: 6.9, p85: 7.9, p97: 8.4),
+    WhoGrowthEntry(ageMonths: 7, p3: 5.9, p15: 6.6, p50: 7.2, p85: 8.2, p97: 8.8),
+    WhoGrowthEntry(ageMonths: 8, p3: 6.1, p15: 6.8, p50: 7.4, p85: 8.5, p97: 9.1),
+    WhoGrowthEntry(ageMonths: 9, p3: 6.3, p15: 7.0, p50: 7.6, p85: 8.7, p97: 9.4),
+    WhoGrowthEntry(ageMonths: 10, p3: 6.5, p15: 7.3, p50: 7.8, p85: 9.0, p97: 9.7),
+    WhoGrowthEntry(ageMonths: 11, p3: 6.6, p15: 7.4, p50: 8.0, p85: 9.2, p97: 9.9),
+    WhoGrowthEntry(ageMonths: 12, p3: 6.8, p15: 7.6, p50: 8.2, p85: 9.4, p97: 10.1),
+    WhoGrowthEntry(ageMonths: 13, p3: 7.0, p15: 7.8, p50: 8.4, p85: 9.6, p97: 10.3),
+    WhoGrowthEntry(ageMonths: 14, p3: 7.1, p15: 8.0, p50: 8.6, p85: 9.8, p97: 10.5),
+    WhoGrowthEntry(ageMonths: 15, p3: 7.3, p15: 8.1, p50: 8.7, p85: 10.0, p97: 10.7),
+    WhoGrowthEntry(ageMonths: 16, p3: 7.4, p15: 8.3, p50: 8.9, p85: 10.2, p97: 10.9),
+    WhoGrowthEntry(ageMonths: 17, p3: 7.6, p15: 8.4, p50: 9.1, p85: 10.4, p97: 11.1),
+    WhoGrowthEntry(ageMonths: 18, p3: 7.7, p15: 8.6, p50: 9.2, p85: 10.5, p97: 11.3),
+    WhoGrowthEntry(ageMonths: 19, p3: 7.9, p15: 8.7, p50: 9.4, p85: 10.7, p97: 11.5),
+    WhoGrowthEntry(ageMonths: 20, p3: 8.0, p15: 8.9, p50: 9.5, p85: 10.9, p97: 11.7),
+    WhoGrowthEntry(ageMonths: 21, p3: 8.1, p15: 9.0, p50: 9.7, p85: 11.1, p97: 11.9),
+    WhoGrowthEntry(ageMonths: 22, p3: 8.3, p15: 9.2, p50: 9.8, p85: 11.3, p97: 12.1),
+    WhoGrowthEntry(ageMonths: 23, p3: 8.4, p15: 9.3, p50: 10.0, p85: 11.5, p97: 12.3),
+    WhoGrowthEntry(ageMonths: 24, p3: 8.5, p15: 9.5, p50: 10.1, p85: 11.7, p97: 12.5),
+  ];
+
+  static const List<WhoGrowthEntry> _headBoys0To24Months = [
+    WhoGrowthEntry(ageMonths: 0, p3: 32.1, p15: 33.2, p50: 34.5, p85: 35.9, p97: 37.0),
+    WhoGrowthEntry(ageMonths: 1, p3: 35.0, p15: 36.1, p50: 37.3, p85: 38.6, p97: 39.7),
+    WhoGrowthEntry(ageMonths: 2, p3: 37.0, p15: 38.1, p50: 39.1, p85: 40.5, p97: 41.6),
+    WhoGrowthEntry(ageMonths: 3, p3: 38.3, p15: 39.3, p50: 40.5, p85: 41.8, p97: 42.9),
+    WhoGrowthEntry(ageMonths: 4, p3: 39.3, p15: 40.3, p50: 41.5, p85: 42.8, p97: 43.9),
+    WhoGrowthEntry(ageMonths: 5, p3: 40.1, p15: 41.1, p50: 42.2, p85: 43.6, p97: 44.8),
+    WhoGrowthEntry(ageMonths: 6, p3: 40.7, p15: 41.8, p50: 42.8, p85: 44.2, p97: 45.4),
+    WhoGrowthEntry(ageMonths: 7, p3: 41.2, p15: 42.3, p50: 43.3, p85: 44.7, p97: 45.9),
+    WhoGrowthEntry(ageMonths: 8, p3: 41.6, p15: 42.7, p50: 43.7, p85: 45.1, p97: 46.3),
+    WhoGrowthEntry(ageMonths: 9, p3: 41.9, p15: 43.0, p50: 44.0, p85: 45.4, p97: 46.7),
+    WhoGrowthEntry(ageMonths: 10, p3: 42.2, p15: 43.3, p50: 44.3, p85: 45.7, p97: 47.0),
+    WhoGrowthEntry(ageMonths: 11, p3: 42.5, p15: 43.5, p50: 44.5, p85: 46.0, p97: 47.3),
+    WhoGrowthEntry(ageMonths: 12, p3: 42.7, p15: 43.7, p50: 44.7, p85: 46.2, p97: 47.5),
+    WhoGrowthEntry(ageMonths: 13, p3: 42.9, p15: 43.9, p50: 44.9, p85: 46.4, p97: 47.7),
+    WhoGrowthEntry(ageMonths: 14, p3: 43.1, p15: 44.1, p50: 45.1, p85: 46.6, p97: 47.9),
+    WhoGrowthEntry(ageMonths: 15, p3: 43.2, p15: 44.2, p50: 45.3, p85: 46.8, p97: 48.1),
+    WhoGrowthEntry(ageMonths: 16, p3: 43.4, p15: 44.4, p50: 45.4, p85: 47.0, p97: 48.2),
+    WhoGrowthEntry(ageMonths: 17, p3: 43.5, p15: 44.5, p50: 45.5, p85: 47.1, p97: 48.4),
+    WhoGrowthEntry(ageMonths: 18, p3: 43.6, p15: 44.6, p50: 45.7, p85: 47.3, p97: 48.5),
+    WhoGrowthEntry(ageMonths: 19, p3: 43.7, p15: 44.7, p50: 45.8, p85: 47.4, p97: 48.6),
+    WhoGrowthEntry(ageMonths: 20, p3: 43.8, p15: 44.8, p50: 45.9, p85: 47.5, p97: 48.7),
+    WhoGrowthEntry(ageMonths: 21, p3: 43.9, p15: 44.9, p50: 46.0, p85: 47.6, p97: 48.8),
+    WhoGrowthEntry(ageMonths: 22, p3: 44.0, p15: 45.0, p50: 46.1, p85: 47.7, p97: 48.9),
+    WhoGrowthEntry(ageMonths: 23, p3: 44.1, p15: 45.1, p50: 46.2, p85: 47.8, p97: 49.0),
+    WhoGrowthEntry(ageMonths: 24, p3: 44.2, p15: 45.2, p50: 46.3, p85: 47.9, p97: 49.1),
+  ];
+
+  static const List<WhoGrowthEntry> _headGirls0To24Months = [
+    WhoGrowthEntry(ageMonths: 0, p3: 31.7, p15: 32.7, p50: 33.9, p85: 35.2, p97: 36.2),
+    WhoGrowthEntry(ageMonths: 1, p3: 34.2, p15: 35.2, p50: 36.4, p85: 37.7, p97: 38.8),
+    WhoGrowthEntry(ageMonths: 2, p3: 35.8, p15: 36.8, p50: 37.9, p85: 39.1, p97: 40.3),
+    WhoGrowthEntry(ageMonths: 3, p3: 36.9, p15: 37.9, p50: 39.0, p85: 40.3, p97: 41.4),
+    WhoGrowthEntry(ageMonths: 4, p3: 37.7, p15: 38.7, p50: 39.8, p85: 41.1, p97: 42.3),
+    WhoGrowthEntry(ageMonths: 5, p3: 38.3, p15: 39.4, p50: 40.4, p85: 41.8, p97: 43.0),
+    WhoGrowthEntry(ageMonths: 6, p3: 38.8, p15: 39.9, p50: 41.0, p85: 42.3, p97: 43.5),
+    WhoGrowthEntry(ageMonths: 7, p3: 39.2, p15: 40.3, p50: 41.3, p85: 42.7, p97: 43.9),
+    WhoGrowthEntry(ageMonths: 8, p3: 39.5, p15: 40.6, p50: 41.7, p85: 43.0, p97: 44.3),
+    WhoGrowthEntry(ageMonths: 9, p3: 39.8, p15: 40.9, p50: 42.0, p85: 43.3, p97: 44.6),
+    WhoGrowthEntry(ageMonths: 10, p3: 40.0, p15: 41.1, p50: 42.2, p85: 43.5, p97: 44.9),
+    WhoGrowthEntry(ageMonths: 11, p3: 40.2, p15: 41.3, p50: 42.4, p85: 43.7, p97: 45.1),
+    WhoGrowthEntry(ageMonths: 12, p3: 40.4, p15: 41.5, p50: 42.6, p85: 43.9, p97: 45.3),
+    WhoGrowthEntry(ageMonths: 13, p3: 40.5, p15: 41.6, p50: 42.7, p85: 44.0, p97: 45.4),
+    WhoGrowthEntry(ageMonths: 14, p3: 40.7, p15: 41.8, p50: 42.9, p85: 44.2, p97: 45.6),
+    WhoGrowthEntry(ageMonths: 15, p3: 40.8, p15: 41.9, p50: 43.0, p85: 44.3, p97: 45.7),
+    WhoGrowthEntry(ageMonths: 16, p3: 40.9, p15: 42.0, p50: 43.1, p85: 44.4, p97: 45.8),
+    WhoGrowthEntry(ageMonths: 17, p3: 41.0, p15: 42.1, p50: 43.2, p85: 44.5, p97: 45.9),
+    WhoGrowthEntry(ageMonths: 18, p3: 41.1, p15: 42.2, p50: 43.3, p85: 44.6, p97: 46.0),
+    WhoGrowthEntry(ageMonths: 19, p3: 41.2, p15: 42.3, p50: 43.4, p85: 44.7, p97: 46.1),
+    WhoGrowthEntry(ageMonths: 20, p3: 41.3, p15: 42.4, p50: 43.5, p85: 44.8, p97: 46.2),
+    WhoGrowthEntry(ageMonths: 21, p3: 41.4, p15: 42.5, p50: 43.6, p85: 44.9, p97: 46.3),
+    WhoGrowthEntry(ageMonths: 22, p3: 41.5, p15: 42.6, p50: 43.7, p85: 44.9, p97: 46.4),
+    WhoGrowthEntry(ageMonths: 23, p3: 41.6, p15: 42.7, p50: 43.8, p85: 45.0, p97: 46.5),
+    WhoGrowthEntry(ageMonths: 24, p3: 41.7, p15: 42.8, p50: 43.9, p85: 45.1, p97: 46.6),
+  ];
+}
+
+class _AgeBracket {
+  const _AgeBracket({required this.lower, required this.upper});
+
+  final WhoGrowthEntry lower;
+  final WhoGrowthEntry upper;
+}

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_growth_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_growth_page.dart
@@ -1,6 +1,8 @@
+import 'package:baby_track_app/features/baby/domain/growth/who_growth_standards.dart';
 import 'package:baby_track_app/features/baby/domain/models/baby.dart';
 import 'package:baby_track_app/features/baby/domain/models/baby_growth_record.dart';
 import 'package:baby_track_app/features/baby/infrastructure/baby_growth_record_repository_impl.dart';
+import 'package:baby_track_app/features/baby/presentation/widgets/who_percentile_chart.dart';
 import 'package:baby_track_app/shared/widgets/app_bars/baby_gradient_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -234,7 +236,14 @@ class _BabyGrowthPageState extends State<BabyGrowthPage> {
                   style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                 ),
                 const SizedBox(height: 12),
-                ...entry.value.map((record) => _GrowthRecordCard(record: record)).toList(),
+                ...entry.value
+                    .map(
+                      (record) => _GrowthRecordCard(
+                        record: record,
+                        baby: widget.baby,
+                      ),
+                    )
+                    .toList(),
               ],
             ),
           ),
@@ -402,9 +411,13 @@ class _MeasurementInputField extends StatelessWidget {
 }
 
 class _GrowthRecordCard extends StatelessWidget {
-  const _GrowthRecordCard({required this.record});
+  const _GrowthRecordCard({required this.record, required this.baby});
 
   final BabyGrowthRecord record;
+  final Baby baby;
+
+  BabyGender get _babyGender =>
+      baby.gender.toUpperCase() == 'F' ? BabyGender.female : BabyGender.male;
 
   String _formatDate(DateTime date) {
     final formatter = DateFormat('d MMM yyyy', 'es');
@@ -418,234 +431,257 @@ class _GrowthRecordCard extends StatelessWidget {
     return '${value.toStringAsFixed(value % 1 == 0 ? 0 : 1)} $unit';
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
+  String _formatAgeDetail() {
+    final birth = baby.birthDate;
+    final measurementDate = record.recordedAt;
+    if (measurementDate.isBefore(birth)) {
+      return 'Edad no disponible';
+    }
 
-    return Container(
-      margin: const EdgeInsets.only(bottom: 16),
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: colorScheme.surface,
-        borderRadius: BorderRadius.circular(24),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 20,
-            offset: const Offset(0, 14),
-          ),
-        ],
-        border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.6)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(Icons.calendar_today_rounded, color: colorScheme.primary),
-              const SizedBox(width: 12),
-              Text(
-                _formatDate(record.recordedAt),
-                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
-              ),
-            ],
-          ),
-          const SizedBox(height: 20),
-          _MeasurementBlock(
-            title: 'Perímetro craneal',
-            valueLabel: _formatMeasurement(record.headCircumferenceCm, 'cm'),
-            percentile: record.headCircumferencePercentile,
-            color: colorScheme.primary,
-          ),
-          const SizedBox(height: 16),
-          _MeasurementBlock(
-            title: 'Altura',
-            valueLabel: _formatMeasurement(record.heightCm, 'cm'),
-            percentile: record.heightPercentile,
-            color: colorScheme.secondary,
-          ),
-          const SizedBox(height: 16),
-          _MeasurementBlock(
-            title: 'Peso',
-            valueLabel: _formatMeasurement(record.weightKg, 'kg'),
-            percentile: record.weightPercentile,
-            color: colorScheme.tertiary,
-          ),
-        ],
-      ),
+    var years = measurementDate.year - birth.year;
+    var months = measurementDate.month - birth.month;
+    var days = measurementDate.day - birth.day;
+
+    if (days < 0) {
+      final previousMonth = DateTime(measurementDate.year, measurementDate.month, 0);
+      days += previousMonth.day;
+      months -= 1;
+    }
+
+    if (months < 0) {
+      years -= 1;
+      months += 12;
+    }
+
+    final parts = <String>[];
+    if (years > 0) {
+      parts.add('$years ${years == 1 ? 'año' : 'años'}');
+    }
+    if (months > 0) {
+      parts.add('$months ${months == 1 ? 'mes' : 'meses'}');
+    }
+    if (days > 0 || parts.isEmpty) {
+      parts.add('$days ${days == 1 ? 'día' : 'días'}');
+    }
+    return parts.join(', ');
+  }
+
+  double _ageInMonths() {
+    final difference = record.recordedAt.difference(baby.birthDate);
+    if (difference.isNegative) {
+      return 0;
+    }
+    return difference.inDays / 30.4375;
+  }
+
+  double? _percentileFor(double? measurement, GrowthMetric metric) {
+    return WhoGrowthStandards.percentileForMeasurement(
+      measurement: measurement,
+      ageMonths: _ageInMonths(),
+      gender: _babyGender,
+      metric: metric,
     );
   }
-}
-
-class _MeasurementBlock extends StatelessWidget {
-  const _MeasurementBlock({
-    required this.title,
-    required this.valueLabel,
-    required this.percentile,
-    required this.color,
-  });
-
-  final String title;
-  final String valueLabel;
-  final double? percentile;
-  final Color color;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          title,
-          style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
+    final ageDetail = _formatAgeDetail();
+    final ageMonths = _ageInMonths();
+
+    final headPercentile =
+        _percentileFor(record.headCircumferenceCm, GrowthMetric.headCircumference);
+    final heightPercentile = _percentileFor(record.heightCm, GrowthMetric.height);
+    final weightPercentile = _percentileFor(record.weightKg, GrowthMetric.weight);
+
+    return DefaultTabController(
+      length: 3,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 16),
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(24),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 20,
+              offset: const Offset(0, 14),
+            ),
+          ],
+          border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.6)),
         ),
-        const SizedBox(height: 6),
-        Row(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(Icons.stacked_line_chart_rounded, color: color),
-            const SizedBox(width: 8),
-            Text(
-              valueLabel,
-              style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600),
+            Row(
+              children: [
+                Icon(Icons.calendar_today_rounded, color: colorScheme.primary),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    '${_formatDate(record.recordedAt)} · $ageDetail',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            TabBar(
+              labelColor: colorScheme.primary,
+              labelPadding: const EdgeInsets.symmetric(horizontal: 12),
+              unselectedLabelColor: colorScheme.onSurface.withOpacity(0.6),
+              indicatorColor: colorScheme.primary,
+              indicatorWeight: 2.5,
+              isScrollable: true,
+              labelStyle: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700),
+              tabs: const [
+                Tab(text: 'Perímetro craneal'),
+                Tab(text: 'Altura'),
+                Tab(text: 'Peso'),
+              ],
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              height: 320,
+              child: TabBarView(
+                physics: const BouncingScrollPhysics(),
+                children: [
+                  _GrowthMetricTab(
+                    metric: GrowthMetric.headCircumference,
+                    title: 'Perímetro craneal',
+                    unit: 'cm',
+                    icon: Icons.circle_outlined,
+                    measurement: record.headCircumferenceCm,
+                    measurementLabel:
+                        _formatMeasurement(record.headCircumferenceCm, 'cm'),
+                    percentile: headPercentile,
+                    gender: _babyGender,
+                    ageMonths: ageMonths,
+                    color: colorScheme.primary,
+                  ),
+                  _GrowthMetricTab(
+                    metric: GrowthMetric.height,
+                    title: 'Altura',
+                    unit: 'cm',
+                    icon: Icons.height_rounded,
+                    measurement: record.heightCm,
+                    measurementLabel: _formatMeasurement(record.heightCm, 'cm'),
+                    percentile: heightPercentile,
+                    gender: _babyGender,
+                    ageMonths: ageMonths,
+                    color: colorScheme.secondary,
+                  ),
+                  _GrowthMetricTab(
+                    metric: GrowthMetric.weight,
+                    title: 'Peso',
+                    unit: 'kg',
+                    icon: Icons.scale_rounded,
+                    measurement: record.weightKg,
+                    measurementLabel: _formatMeasurement(record.weightKg, 'kg'),
+                    percentile: weightPercentile,
+                    gender: _babyGender,
+                    ageMonths: ageMonths,
+                    color: colorScheme.tertiary,
+                  ),
+                ],
+              ),
             ),
           ],
         ),
-        const SizedBox(height: 12),
-        if (percentile != null)
-          _PercentileBar(percentile: percentile!, color: color)
-        else
-          Text(
-            'Añade los percentiles para visualizar la curva de crecimiento.',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: colorScheme.onSurface.withOpacity(0.6),
-            ),
-          ),
-      ],
+      ),
     );
   }
 }
 
-class _PercentileBar extends StatelessWidget {
-  const _PercentileBar({required this.percentile, required this.color});
+class _GrowthMetricTab extends StatelessWidget {
+  const _GrowthMetricTab({
+    required this.metric,
+    required this.title,
+    required this.unit,
+    required this.icon,
+    required this.measurement,
+    required this.measurementLabel,
+    required this.percentile,
+    required this.gender,
+    required this.ageMonths,
+    required this.color,
+  });
 
-  final double percentile;
+  final GrowthMetric metric;
+  final String title;
+  final String unit;
+  final IconData icon;
+  final double? measurement;
+  final String measurementLabel;
+  final double? percentile;
+  final BabyGender gender;
+  final double ageMonths;
   final Color color;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final textTheme = theme.textTheme;
-    final clamped = percentile.clamp(0, 100).toDouble();
+    final colorScheme = theme.colorScheme;
+
+    final percentileLabel = percentile == null
+        ? 'Sin percentil disponible'
+        : 'Percentil ${percentile!.clamp(0, 100).round()} (OMS)';
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SizedBox(
-          height: 48,
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final widthFactor = constraints.maxWidth == 0
-                  ? 0.0
-                  : (clamped / 100).clamp(0.0, 1.0);
-              final markerPosition = constraints.maxWidth * widthFactor;
-
-              return Stack(
-                children: [
-                  Container(
-                    height: 48,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(16),
-                      gradient: LinearGradient(
-                        colors: [color.withOpacity(0.2), color.withOpacity(0.05)],
-                      ),
-                      border: Border.all(color: color.withOpacity(0.35)),
-                    ),
-                  ),
-                  Positioned.fill(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: ClipRRect(
-                              borderRadius: BorderRadius.circular(10),
-                              child: Align(
-                                alignment: Alignment.centerLeft,
-                                child: FractionallySizedBox(
-                                  widthFactor: widthFactor,
-                                  child: Container(
-                                    decoration: BoxDecoration(
-                                      gradient: LinearGradient(
-                                        begin: Alignment.centerLeft,
-                                        end: Alignment.centerRight,
-                                        colors: [color, color.withOpacity(0.6)],
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  Positioned(
-                    left: markerPosition.clamp(12.0, constraints.maxWidth - 12),
-                    top: 8,
-                    child: _PercentileMarker(color: color),
-                  ),
-                ],
-              );
-            },
+        Row(
+          children: [
+            Icon(icon, color: color),
+            const SizedBox(width: 8),
+            Text(
+              title,
+              style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Medición: $measurementLabel',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          percentileLabel,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurface.withOpacity(0.7),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceVariant.withOpacity(0.25),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: WhoPercentileChart(
+                  metric: metric,
+                  gender: gender,
+                  measurement: measurement,
+                  ageMonths: ageMonths,
+                ),
+              ),
+            ),
           ),
         ),
         const SizedBox(height: 8),
         Text(
-          'Percentil ${clamped.toStringAsFixed(0)}',
-          style: textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
-        ),
-      ],
-    );
-  }
-}
-
-class _PercentileMarker extends StatelessWidget {
-  const _PercentileMarker({required this.color});
-
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Container(
-          width: 4,
-          height: 20,
-          decoration: BoxDecoration(
-            color: color,
-            borderRadius: BorderRadius.circular(2),
-            boxShadow: [
-              BoxShadow(
-                color: color.withOpacity(0.4),
-                blurRadius: 8,
-                offset: const Offset(0, 3),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 4),
-        Container(
-          width: 10,
-          height: 10,
-          decoration: BoxDecoration(
-            color: color,
-            shape: BoxShape.circle,
-            border: Border.all(color: Colors.white, width: 1.5),
+          'Fuente: Estándares de crecimiento OMS 2006.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurface.withOpacity(0.6),
           ),
         ),
       ],

--- a/baby_track_app/lib/features/baby/presentation/widgets/who_percentile_chart.dart
+++ b/baby_track_app/lib/features/baby/presentation/widgets/who_percentile_chart.dart
@@ -1,0 +1,200 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../domain/growth/who_growth_standards.dart';
+
+class WhoPercentileChart extends StatelessWidget {
+  const WhoPercentileChart({
+    super.key,
+    required this.metric,
+    required this.gender,
+    required this.measurement,
+    required this.ageMonths,
+  });
+
+  final GrowthMetric metric;
+  final BabyGender gender;
+  final double? measurement;
+  final double ageMonths;
+
+  @override
+  Widget build(BuildContext context) {
+    final data = WhoGrowthStandards.entriesFor(gender: gender, metric: metric);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return _WhoChartPainterWidget(
+          data: data,
+          measurement: measurement,
+          ageMonths: ageMonths,
+        );
+      },
+    );
+  }
+}
+
+class _WhoChartPainterWidget extends StatelessWidget {
+  const _WhoChartPainterWidget({
+    required this.data,
+    required this.measurement,
+    required this.ageMonths,
+  });
+
+  final List<WhoGrowthEntry> data;
+  final double? measurement;
+  final double ageMonths;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return CustomPaint(
+      painter: _WhoChartPainter(
+        data: data,
+        measurement: measurement,
+        ageMonths: ageMonths,
+        axisColor: colorScheme.outlineVariant.withOpacity(0.6),
+        percentileColors: [
+          colorScheme.error.withOpacity(0.45),
+          colorScheme.tertiary.withOpacity(0.55),
+          colorScheme.primary,
+          colorScheme.secondary,
+          colorScheme.primary.withOpacity(0.8),
+        ],
+        measurementColor: colorScheme.primary,
+      ),
+      child: const SizedBox.expand(),
+    );
+  }
+}
+
+class _WhoChartPainter extends CustomPainter {
+  _WhoChartPainter({
+    required this.data,
+    required this.measurement,
+    required this.ageMonths,
+    required this.axisColor,
+    required this.percentileColors,
+    required this.measurementColor,
+  });
+
+  final List<WhoGrowthEntry> data;
+  final double? measurement;
+  final double ageMonths;
+  final Color axisColor;
+  final List<Color> percentileColors;
+  final Color measurementColor;
+
+  static const double _paddingLeft = 36;
+  static const double _paddingRight = 16;
+  static const double _paddingTop = 16;
+  static const double _paddingBottom = 28;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (data.isEmpty) {
+      return;
+    }
+
+    final chartWidth = size.width - _paddingLeft - _paddingRight;
+    final chartHeight = size.height - _paddingTop - _paddingBottom;
+    if (chartWidth <= 0 || chartHeight <= 0) {
+      return;
+    }
+
+    final minAge = data.first.ageMonths;
+    final maxAge = data.last.ageMonths;
+    double minValue = data.first.p3;
+    double maxValue = data.first.p97;
+    for (final entry in data) {
+      minValue = math.min(minValue, entry.p3);
+      maxValue = math.max(maxValue, entry.p97);
+    }
+    final range = maxValue - minValue;
+    final verticalPadding = range * 0.08;
+    minValue -= verticalPadding;
+    maxValue += verticalPadding;
+
+    double toChartX(double age) {
+      final normalized = (age - minAge) / (maxAge - minAge);
+      return _paddingLeft + normalized * chartWidth;
+    }
+
+    double toChartY(double value) {
+      final normalized = (value - minValue) / (maxValue - minValue);
+      return _paddingTop + (1 - normalized) * chartHeight;
+    }
+
+    final axisPaint = Paint()
+      ..color = axisColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1;
+
+    // Draw axes.
+    final baselineY = _paddingTop + chartHeight;
+    canvas.drawLine(Offset(_paddingLeft, _paddingTop), Offset(_paddingLeft, baselineY), axisPaint);
+    canvas.drawLine(Offset(_paddingLeft, baselineY), Offset(_paddingLeft + chartWidth, baselineY), axisPaint);
+
+    // Horizontal grid lines
+    final gridPaint = Paint()
+      ..color = axisColor.withOpacity(0.45)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.5;
+    const gridCount = 4;
+    for (var i = 1; i <= gridCount; i++) {
+      final y = _paddingTop + chartHeight * (i / (gridCount + 1));
+      canvas.drawLine(Offset(_paddingLeft, y), Offset(_paddingLeft + chartWidth, y), gridPaint);
+    }
+
+    final percentilePaths = List.generate(percentileColors.length, (_) => Path());
+    for (var entryIndex = 0; entryIndex < data.length; entryIndex++) {
+      final entry = data[entryIndex];
+      final x = toChartX(entry.ageMonths);
+      final values = entry.percentileValues;
+      for (var i = 0; i < values.length; i++) {
+        final y = toChartY(values[i]);
+        final path = percentilePaths[i];
+        if (entryIndex == 0) {
+          path.moveTo(x, y);
+        } else {
+          path.lineTo(x, y);
+        }
+      }
+    }
+
+    for (var i = 0; i < percentilePaths.length; i++) {
+      final paint = Paint()
+        ..color = percentileColors[i]
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = i == 2 ? 2.4 : 1.6;
+      canvas.drawPath(percentilePaths[i], paint);
+    }
+
+    if (measurement != null) {
+      final clampedAge = ageMonths.clamp(minAge, maxAge);
+      final x = toChartX(clampedAge);
+      final y = toChartY(measurement!.clamp(minValue, maxValue));
+
+      final markerPaint = Paint()
+        ..color = measurementColor.withOpacity(0.25)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.2;
+      canvas.drawLine(Offset(x, _paddingTop), Offset(x, baselineY), markerPaint);
+
+      final pointPaint = Paint()..color = measurementColor;
+      canvas.drawCircle(Offset(x, y), 5, pointPaint);
+      canvas.drawCircle(Offset(x, y), 8, Paint()
+        ..color = measurementColor.withOpacity(0.18)
+        ..style = PaintingStyle.fill);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _WhoChartPainter oldDelegate) {
+    return oldDelegate.data != data ||
+        oldDelegate.measurement != measurement ||
+        oldDelegate.ageMonths != ageMonths ||
+        oldDelegate.axisColor != axisColor;
+  }
+}


### PR DESCRIPTION
## Summary
- add WHO growth standard percentile tables for weight, height and head circumference (0-24 meses)
- refactor growth record cards to show tabs with OMS percentile charts and display precise age per measurement
- build reusable percentile chart widget to render curves and highlight the stored measurement

## Testing
- not run (flutter not available in container)

## Agent
- Responsable: Agente UI/UX

------
https://chatgpt.com/codex/tasks/task_b_68debcec177483328dd176d77ff7b0d0