### PR TITLE
feat: add CSV import/export options for baby history

### DIFF
--- a/baby_track_app/lib/features/baby/application/services/baby_daily_log_csv_service.dart
+++ b/baby_track_app/lib/features/baby/application/services/baby_daily_log_csv_service.dart
@@ -1,0 +1,364 @@
+import 'package:baby_track_app/features/baby/domain/models/baby_daily_log.dart';
+import 'package:baby_track_app/features/baby/domain/repositories/baby_daily_log_repository.dart';
+import 'package:csv/csv.dart';
+import 'package:intl/intl.dart';
+
+class BabyDailyLogCsvService {
+  BabyDailyLogCsvService({required BabyDailyLogRepository logRepository})
+      : _logRepository = logRepository;
+
+  final BabyDailyLogRepository _logRepository;
+
+  static const List<String> _standardHeader = <String>[
+    'date',
+    'time',
+    'intake_ml',
+    'did_poop',
+    'showered',
+    'vomited',
+    'notes',
+  ];
+
+  Future<String> exportLogsAsCsv(int babyId) async {
+    final logs = await _logRepository.getAllLogsForBaby(babyId);
+
+    final rows = <List<dynamic>>[_standardHeader];
+    final dayFormatter = DateFormat('yyyy-MM-dd');
+    final timeFormatter = DateFormat('HH:mm');
+
+    for (final log in logs) {
+      rows.add(<dynamic>[
+        dayFormatter.format(log.logDay),
+        timeFormatter.format(log.loggedAt),
+        log.intakeMl?.toString() ?? '',
+        log.didPoop,
+        log.showered,
+        log.vomited,
+        log.notes ?? '',
+      ]);
+    }
+
+    return const ListToCsvConverter().convert(rows);
+  }
+
+  Future<int> importStandardCsv({
+    required int babyId,
+    required String csvContent,
+  }) async {
+    final rows = const CsvToListConverter().convert(
+      csvContent,
+      shouldParseNumbers: false,
+    );
+
+    if (rows.isEmpty) {
+      return 0;
+    }
+
+    final header = rows.first
+        .map((dynamic value) => value.toString().trim().toLowerCase())
+        .toList();
+
+    final dateIndex = header.indexOf('date');
+    final timeIndex = header.indexOf('time');
+
+    if (dateIndex == -1 || timeIndex == -1) {
+      throw const FormatException(
+        'El CSV debe contener al menos las columnas "date" y "time".',
+      );
+    }
+
+    final intakeIndex = header.indexOf('intake_ml');
+    final poopIndex = header.indexOf('did_poop');
+    final showerIndex = header.indexOf('showered');
+    final vomitIndex = header.indexOf('vomited');
+    final notesIndex = header.indexOf('notes');
+
+    var imported = 0;
+
+    for (var i = 1; i < rows.length; i++) {
+      final row = rows[i];
+
+      final dateString = _readCell(row, dateIndex);
+      final timeString = _readCell(row, timeIndex);
+
+      if (dateString == null || timeString == null) {
+        continue;
+      }
+
+      final loggedAt = _combineDateAndTime(dateString, timeString);
+      if (loggedAt == null) {
+        continue;
+      }
+
+      final intakeValue = _readCell(row, intakeIndex);
+      final didPoopValue = _readCell(row, poopIndex);
+      final showerValue = _readCell(row, showerIndex);
+      final vomitValue = _readCell(row, vomitIndex);
+      final notesValue = _readCell(row, notesIndex);
+
+      final log = BabyDailyLog(
+        babyId: babyId,
+        logDay: DateTime(loggedAt.year, loggedAt.month, loggedAt.day),
+        loggedAt: loggedAt,
+        intakeMl: _parseInt(intakeValue),
+        didPoop: _parseBool(didPoopValue),
+        showered: _parseBool(showerValue),
+        vomited: _parseBool(vomitValue),
+        notes: notesValue?.replaceAll('\\n', '\n'),
+        createdAt: DateTime.now(),
+      );
+
+      await _logRepository.createLog(log);
+      imported++;
+    }
+
+    return imported;
+  }
+
+  Future<int> importLegacyCsv({
+    required int babyId,
+    required String csvContent,
+  }) async {
+    final rows = const CsvToListConverter().convert(
+      csvContent,
+      shouldParseNumbers: false,
+    );
+
+    if (rows.isEmpty) {
+      return 0;
+    }
+
+    final header = rows.first
+        .map((dynamic value) => _normalizeHeader(value.toString()))
+        .toList();
+
+    final dateIndex = header.indexOf('fecha');
+    final timeIndex = header.indexOf('hora');
+
+    if (dateIndex == -1 || timeIndex == -1) {
+      throw const FormatException(
+        'El CSV anterior debe tener las columnas "Fecha" y "Hora".',
+      );
+    }
+
+    final bottleIndex = header.indexOf('biberon (ml)');
+    final poopIndex = header.indexOf('caca');
+    final vomitIndex = header.indexOf('vomito');
+    final bathIndex = header.indexOf('bano');
+
+    var imported = 0;
+
+    for (var i = 1; i < rows.length; i++) {
+      final row = rows[i];
+      final dateString = _readCell(row, dateIndex);
+      final timeString = _readCell(row, timeIndex);
+
+      if (dateString == null || timeString == null) {
+        continue;
+      }
+
+      final loggedAt = _combineDateAndTime(dateString, timeString);
+      if (loggedAt == null) {
+        continue;
+      }
+
+      final intakeValue = _readCell(row, bottleIndex);
+      final poopValue = _readCell(row, poopIndex);
+      final vomitValue = _readCell(row, vomitIndex);
+      final bathValue = _readCell(row, bathIndex);
+
+      final log = BabyDailyLog(
+        babyId: babyId,
+        logDay: DateTime(loggedAt.year, loggedAt.month, loggedAt.day),
+        loggedAt: loggedAt,
+        intakeMl: _parseInt(intakeValue),
+        didPoop: _parseBool(poopValue),
+        vomited: _parseBool(vomitValue),
+        showered: _parseBool(bathValue),
+        createdAt: DateTime.now(),
+      );
+
+      await _logRepository.createLog(log);
+      imported++;
+    }
+
+    return imported;
+  }
+
+  String? _readCell(List<dynamic> row, int index) {
+    if (index < 0 || index >= row.length) {
+      return null;
+    }
+    final dynamic value = row[index];
+    if (value == null) {
+      return null;
+    }
+    final result = value.toString().trim();
+    if (result.isEmpty) {
+      return null;
+    }
+    return result;
+  }
+
+  DateTime? _combineDateAndTime(String dateString, String timeString) {
+    final normalizedTime = timeString.replaceAll('.', ':');
+    final date = DateTime.tryParse(dateString);
+    if (date == null) {
+      return null;
+    }
+
+    final timeParts = normalizedTime.split(':');
+    if (timeParts.length < 2) {
+      return null;
+    }
+
+    final hour = int.tryParse(timeParts[0]);
+    final minute = int.tryParse(timeParts[1]);
+    if (hour == null || minute == null) {
+      return null;
+    }
+
+    return DateTime(date.year, date.month, date.day, hour, minute);
+  }
+
+  int? _parseInt(String? value) {
+    if (value == null) {
+      return null;
+    }
+    final cleaned = value.replaceAll(RegExp('[^0-9-]'), '');
+    if (cleaned.isEmpty) {
+      return null;
+    }
+    return int.tryParse(cleaned);
+  }
+
+  bool _parseBool(String? value) {
+    if (value == null) {
+      return false;
+    }
+    final normalized = _normalizeValue(value);
+    if (normalized.isEmpty) {
+      return false;
+    }
+
+    const truthy = <String>{
+      '1',
+      'true',
+      't',
+      'si',
+      'sí',
+      's',
+      'x',
+      'yes',
+      'y',
+    };
+
+    return truthy.contains(normalized);
+  }
+
+  String _normalizeValue(String value) {
+    var normalized = value.toLowerCase().trim();
+    const replacements = <String, String>{
+      'á': 'a',
+      'à': 'a',
+      'ä': 'a',
+      'â': 'a',
+      'ã': 'a',
+      'é': 'e',
+      'è': 'e',
+      'ë': 'e',
+      'ê': 'e',
+      'í': 'i',
+      'ì': 'i',
+      'ï': 'i',
+      'î': 'i',
+      'ó': 'o',
+      'ò': 'o',
+      'ö': 'o',
+      'ô': 'o',
+      'õ': 'o',
+      'ú': 'u',
+      'ù': 'u',
+      'ü': 'u',
+      'û': 'u',
+      'ñ': 'n',
+      'Ã¡': 'a',
+      'Ã¢': 'a',
+      'Ã¤': 'a',
+      'Â': '',
+      'Ã©': 'e',
+      'Ã«': 'e',
+      'Ã¨': 'e',
+      'Ã­': 'i',
+      'Ã¯': 'i',
+      'Ã²': 'o',
+      'Ã³': 'o',
+      'Ã¶': 'o',
+      'Ãµ': 'o',
+      'Ãº': 'u',
+      'Ã¼': 'u',
+      'Ã¹': 'u',
+      'Ã±': 'n',
+    };
+
+    replacements.forEach((String key, String value) {
+      normalized = normalized.replaceAll(key, value);
+    });
+
+    normalized = normalized.replaceAll(RegExp('[^a-z0-9]'), '');
+    return normalized;
+  }
+
+  String _normalizeHeader(String value) {
+    var normalized = value.toLowerCase().trim();
+
+    const replacements = <String, String>{
+      'á': 'a',
+      'à': 'a',
+      'ä': 'a',
+      'â': 'a',
+      'ã': 'a',
+      'é': 'e',
+      'è': 'e',
+      'ë': 'e',
+      'ê': 'e',
+      'í': 'i',
+      'ì': 'i',
+      'ï': 'i',
+      'î': 'i',
+      'ó': 'o',
+      'ò': 'o',
+      'ö': 'o',
+      'ô': 'o',
+      'õ': 'o',
+      'ú': 'u',
+      'ù': 'u',
+      'ü': 'u',
+      'û': 'u',
+      'ñ': 'n',
+      'Ã¡': 'a',
+      'Ã¢': 'a',
+      'Ã¤': 'a',
+      'Ã©': 'e',
+      'Ã«': 'e',
+      'Ã¨': 'e',
+      'Ã­': 'i',
+      'Ã¯': 'i',
+      'Ã³': 'o',
+      'Ã´': 'o',
+      'Ã¶': 'o',
+      'Ãµ': 'o',
+      'Ãº': 'u',
+      'Ã¼': 'u',
+      'Ã¹': 'u',
+      'Ã±': 'n',
+    };
+
+    replacements.forEach((String key, String value) {
+      normalized = normalized.replaceAll(key, value);
+    });
+
+    normalized = normalized.replaceAll(RegExp('[^a-z0-9 ()/_-]'), '');
+    return normalized;
+  }
+}

--- a/baby_track_app/lib/features/baby/presentation/pages/baby_history_page.dart
+++ b/baby_track_app/lib/features/baby/presentation/pages/baby_history_page.dart
@@ -1,10 +1,16 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:baby_track_app/features/baby/application/services/baby_daily_log_csv_service.dart';
 import 'package:baby_track_app/features/baby/domain/models/baby.dart';
 import 'package:baby_track_app/features/baby/domain/models/baby_daily_log.dart';
 import 'package:baby_track_app/features/baby/domain/repositories/baby_daily_log_repository.dart';
 import 'package:baby_track_app/features/baby/infrastructure/baby_daily_log_repository_impl.dart';
 import 'package:baby_track_app/shared/widgets/app_bars/baby_gradient_app_bar.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:share_plus/share_plus.dart';
 
 class BabyHistoryPage extends StatefulWidget {
   const BabyHistoryPage({super.key, required this.baby});
@@ -17,6 +23,8 @@ class BabyHistoryPage extends StatefulWidget {
 
 class _BabyHistoryPageState extends State<BabyHistoryPage> {
   final BabyDailyLogRepository _logRepository = BabyDailyLogRepositoryImpl();
+  late final BabyDailyLogCsvService _csvService =
+      BabyDailyLogCsvService(logRepository: _logRepository);
   List<BabyDailyLog> _allLogs = [];
   final Map<String, List<BabyDailyLog>> _groupedLogs = {};
   final Set<String> _collapsedDays = {};
@@ -69,6 +77,189 @@ class _BabyHistoryPageState extends State<BabyHistoryPage> {
     }
 
     _collapsedDays.removeWhere((day) => !_groupedLogs.containsKey(day));
+  }
+
+  Future<void> _showCsvOptions() async {
+    if (widget.baby.id == null) {
+      _showSnackBar('Debes guardar el perfil del bebé antes de exportar o importar.');
+      return;
+    }
+
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (BuildContext context) {
+        final colorScheme = Theme.of(context).colorScheme;
+        final textTheme = Theme.of(context).textTheme;
+
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: Icon(Icons.ios_share_rounded, color: colorScheme.primary),
+                title: Text('Exportar historial a CSV', style: textTheme.titleSmall),
+                subtitle: Text(
+                  'Genera un archivo compatible con la app',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  _exportCsv();
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.upload_file_rounded, color: colorScheme.primary),
+                title: Text('Importar CSV actual', style: textTheme.titleSmall),
+                subtitle: Text(
+                  'Usa archivos exportados desde Baby Track',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  _importStandardCsv();
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.history_rounded, color: colorScheme.secondary),
+                title:
+                    Text('Importar CSV app anterior (temporal)', style: textTheme.titleSmall),
+                subtitle: Text(
+                  'Permite migrar los datos del formato antiguo mostrado en la imagen.',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  _importLegacyCsv();
+                },
+              ),
+              const SizedBox(height: 12),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _exportCsv() async {
+    final babyId = widget.baby.id;
+    if (babyId == null) {
+      _showSnackBar('No se pudo exportar porque el bebé no está guardado.');
+      return;
+    }
+
+    try {
+      final csvContent = await _csvService.exportLogsAsCsv(babyId);
+      final sanitizedName = widget.baby.name
+          .toLowerCase()
+          .replaceAll(RegExp('[^a-z0-9]+'), '_')
+          .replaceAll(RegExp('_+'), '_')
+          .replaceAll(RegExp(r'^_+|_+\$'), '')
+          .trim();
+      final timestamp = DateFormat('yyyyMMdd_HHmmss').format(DateTime.now());
+      final fileName = '${sanitizedName.isEmpty ? 'historial' : sanitizedName}_$timestamp.csv';
+
+      final bytes = Uint8List.fromList(utf8.encode(csvContent));
+
+      await Share.shareXFiles(
+        <XFile>[
+          XFile.fromData(
+            bytes,
+            mimeType: 'text/csv',
+            name: fileName,
+          ),
+        ],
+        subject: 'Historial de ${widget.baby.name}',
+        text: 'Historial de registros de ${widget.baby.name}.',
+      );
+
+      _showSnackBar('Historial exportado en CSV.');
+    } catch (error) {
+      _showSnackBar('No se pudo exportar el historial: $error');
+    }
+  }
+
+  Future<void> _importStandardCsv() async {
+    await _handleCsvImport((String csv) async {
+      final babyId = widget.baby.id;
+      if (babyId == null) {
+        return 0;
+      }
+      return _csvService.importStandardCsv(babyId: babyId, csvContent: csv);
+    });
+  }
+
+  Future<void> _importLegacyCsv() async {
+    await _handleCsvImport((String csv) async {
+      final babyId = widget.baby.id;
+      if (babyId == null) {
+        return 0;
+      }
+      return _csvService.importLegacyCsv(babyId: babyId, csvContent: csv);
+    });
+  }
+
+  Future<void> _handleCsvImport(
+    Future<int> Function(String csvContent) importer,
+  ) async {
+    final babyId = widget.baby.id;
+    if (babyId == null) {
+      _showSnackBar('Debes guardar el perfil del bebé antes de importar registros.');
+      return;
+    }
+
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['csv'],
+        withData: true,
+      );
+
+      if (result == null || result.files.isEmpty) {
+        return;
+      }
+
+      final pickedFile = result.files.first;
+      final fileBytes = pickedFile.bytes;
+
+      if (fileBytes == null) {
+        _showSnackBar('No se pudo leer el archivo seleccionado.');
+        return;
+      }
+
+      final csvContent = utf8.decode(fileBytes, allowMalformed: true);
+      final imported = await importer(csvContent);
+
+      if (imported > 0) {
+        await _loadAllLogs();
+        _showSnackBar('$imported registros importados correctamente.');
+      } else {
+        _showSnackBar('No se agregaron registros nuevos desde el archivo.');
+      }
+    } on FormatException catch (error) {
+      _showSnackBar('El archivo no tiene el formato esperado: ${error.message}');
+    } catch (error) {
+      _showSnackBar('Ocurrió un error al importar el CSV: $error');
+    }
+  }
+
+  void _showSnackBar(String message) {
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
   }
 
   void _toggleFilter(String dayKey, String filterType) {
@@ -146,6 +337,16 @@ class _BabyHistoryPageState extends State<BabyHistoryPage> {
         subtitle: 'Registro de ${widget.baby.name}',
         icon: Icons.history_rounded,
         toolbarHeight: 100,
+        actions: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: IconButton(
+              tooltip: 'Importar o exportar historial',
+              icon: const Icon(Icons.import_export_rounded, color: Colors.white),
+              onPressed: _showCsvOptions,
+            ),
+          ),
+        ],
       ),
       body: Container(
         decoration: BoxDecoration(

--- a/baby_track_app/pubspec.yaml
+++ b/baby_track_app/pubspec.yaml
@@ -47,6 +47,9 @@ dependencies:
   # Utilities
   intl: ^0.20.2
   shared_preferences: ^2.2.2
+  csv: ^5.1.1
+  file_picker: ^6.1.1
+  share_plus: ^10.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add CSV, file picker, and share dependencies to support data exchange
- implement a CSV service to export logs and import both current and legacy formats
- expose export/import actions on the history page with UI to trigger the flows

## Testing
- Not run (environment missing Flutter SDK)


------
https://chatgpt.com/codex/tasks/task_b_68dec3191c84833284b5543cf774f8a5